### PR TITLE
add investigation cost guardrail skill

### DIFF
--- a/skills/investigation-cost-guardrail/CHANGELOG.md
+++ b/skills/investigation-cost-guardrail/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.0.0
+
+- Initial version

--- a/skills/investigation-cost-guardrail/README.md
+++ b/skills/investigation-cost-guardrail/README.md
@@ -1,0 +1,181 @@
+# Investigation Cost Guardrail
+
+![Investigation Cost Guardrail Workflow](assets/devops-agent.drawio.png)
+
+A pre-investigation cost estimation skill for AWS DevOps Agent. It queries the actual data volume an investigation would scan, calculates the dollar cost **before** any query runs, and cancels if the cost exceeds a configurable threshold. It always guides the user on how to reduce scope and cost.
+
+## ⚠️ Disclaimer
+
+This skill is sample code provided for educational and demonstration purposes. It is **not intended for production use** without additional review, testing, and validation. Validate in a non-production environment first and adjust thresholds, IAM permissions, and log group scoping to match your organization's requirements.
+
+## Why This Skill Exists
+
+AWS DevOps Agent works backwards from the incident, identifying the right observability signals, querying the right data sources, and correlating findings across services to help reduce MTTR and minimize customer impact.
+
+In large production environments with high log ingestion rates, a broad investigation can scan significant data volumes. This skill gives operators visibility into that cost upfront, so they can make an informed decision: proceed as-is, narrow the scope, or approve a higher budget. It answers the question "How much will this investigation cost me?" before the first query runs.
+
+## The Insight
+
+You can estimate CloudWatch Logs Insights cost **before** running a single query.
+
+CloudWatch publishes an `IncomingBytes` metric for every log group: exactly how many bytes were ingested during any time period. Since Logs Insights charges per GB scanned, and the scan volume equals the data within the query's time window, you can calculate the cost in advance:
+
+```
+cost = IncomingBytes(time_window) / 1e9 × regional_rate
+```
+
+Because the estimate is grounded in the log group's actual ingested volume rather than a heuristic, it reflects what a query over that window will genuinely scan. Volume is computed in GB, and `regional_rate` is resolved at runtime via the AWS Price List API. A representative Logs Insights rate is ~$0.005/GB, though it varies by region.
+
+The same before-you-run principle extends to the other cost components: GetMetricData is priced from the metric-and-period count, X-Ray from the trace count, and cross-region transfer from the result bytes returned, each at its own per-region rate.
+
+## How It Works
+
+Before any investigation begins, the guardrail:
+
+1. **Plans:** identifies every data source the investigation will call (CloudWatch log groups, metric namespaces, X-Ray, CloudTrail) and the regions involved, then builds a step-by-step investigation plan
+2. **Measures:** quantifies the real volume for each step, scoped to the user's time window: bytes to scan per log group (`IncomingBytes`), metrics × periods to fetch, traces to pull, and any cross-region results
+3. **Prices:** calculates the cost per step using the per-region rate, including cross-region data transfer where the workload and Agent Space regions differ
+4. **Decides:** proceed (≤ threshold), or cancel and request operator approval (> threshold)
+
+If no time window is provided, the guardrail fetches total `storedBytes` per log group (worst case) and cancels immediately, asking the user to provide a specific time window.
+
+### Cost Components the Guardrail Estimates
+
+The investigation can call several pay-per-use APIs. The guardrail estimates each and shows every line in the plan:
+
+| Component | Billed on |
+|---|---|
+| CloudWatch Logs Insights | per GB scanned |
+| CloudWatch GetMetricData | per 1,000 metrics requested |
+| AWS X-Ray | per million traces scanned/retrieved |
+| CloudWatch Contributor Insights | per million matching events |
+| CloudWatch Live Tail | per streaming minute |
+| Cross-region data transfer | $0.02/GB on results returned across regions |
+
+Shown in the plan at **$0.00** for transparency (free or negligible): `CloudWatch Logs FilterLogEvents`, `CloudTrail LookupEvents`, `EC2/ECS/RDS Describe*`, and `GetMetricStatistics`.
+
+### Estimate Accuracy
+
+The figures shown are a pre-flight approximation intended to inform a proceed or cancel decision. Actual charges can differ, by design the skill leans conservative, favoring worst-case assumptions when data is uncertain, which is the appropriate bias for a guardrail.
+
+## Scenarios
+
+**Scenario A: Scoped investigation, within threshold**
+```
+User: "Investigate the ECS task crashes on payments-api, 14:00-14:30 UTC today"
+
+  📋 Pre-Investigation Plan (threshold: $10.00)
+  1. Logs Insights  /aws/ecs/payments-api    → 6.4 GB
+  2. Logs Insights  /aws/ecs/payments-worker → 2.1 GB
+  3. GetMetricData  6 metrics × 30 periods
+  4. X-Ray traces   ~18,000
+
+  💰 Cost Estimate:
+  - Logs Insights:  8.5 GB × rate   = $0.0425
+  - GetMetricData:  180 requests    = $0.0018
+  - X-Ray:          18,000 traces   = $0.0090
+  - Total:                            $0.0533
+
+  ✅ PROCEEDING: $0.05 is within the $10.00 threshold.
+```
+
+**Scenario B: Broad investigation, exceeds threshold**
+```
+User: "Investigate intermittent platform latency over the last 7 days"
+
+  📋 Pre-Investigation Plan (threshold: $10.00)
+  1. Logs Insights  5 log groups, 7-day window → 2,850 GB
+  2. GetMetricData  40 metrics × 2,016 periods
+  3. X-Ray traces   ~3,200,000
+  4. Cross-region   results us-east-1 ← eu-west-1
+
+  💰 Cost Estimate:
+  - Logs Insights:      2,850 GB × rate     = $14.25
+  - GetMetricData:      80,640 requests     = $0.81
+  - X-Ray:              3.2M traces         = $1.60
+  - Cross-region xfer:  ~85 GB × $0.02      = $1.71
+  - Total:                                    $18.37
+
+  🚫 CANCELLED: estimated cost ($18.37) exceeds the $10.00 threshold.
+
+  💡 Suggestions to reduce cost:
+  - Narrow to a 1-hour window around the spike → ~$0.12
+  - Target the specific service instead of all 5 log groups
+  - Provide the exact error/latency signature → use FilterLogEvents (free)
+  - "Same region only" → removes the $1.71 cross-region transfer
+
+  Approve to proceed at $18.37, or provide a narrower scope.
+```
+
+
+
+## Cross-Region Data Transfer
+
+When the Agent Space region differs from the workload region, query **results** returned across regions incur cross-region data transfer ($0.02/GB). The guardrail detects the mismatch and adds an estimated transfer cost based on the result bytes returned (aggregations return almost nothing; raw fetches can return more), not the full scanned volume.
+
+## Benefits
+
+| Capability | What It Gives the User |
+|---|---|
+| **Cost transparency** | See the exact cost of every investigation step before it runs |
+| **Safe experimentation** | In dev/staging, teams exploring the agent's capabilities can keep costs minimal |
+| **Production control** | Set a threshold and stay in control |
+| **Smarter scoping** | When cancelled, the skill tells the user exactly how to make the investigation cost effective |
+| **Visibility and choice** | Users decide: proceed, narrow scope, or approve a higher budget |
+
+## Technical Implementation
+
+The skill relies on AWS APIs that are themselves free or negligible:
+
+- `logs:DescribeLogGroups`: `storedBytes` per log group (free)
+- `cloudwatch:GetMetricStatistics` (`AWS/Logs` / `IncomingBytes`): actual bytes ingested in the window (~$0.01 per 1,000 requests)
+- `pricing:GetProducts`: resolves the per-region rate at runtime (free)
+
+The cost of running the guardrail itself is effectively **$0.00** (excluding agent compute time): a few free API calls that provide full cost visibility before any paid query executes.
+
+## Required IAM Permissions
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "logs:DescribeLogGroups",
+    "cloudwatch:GetMetricStatistics",
+    "pricing:GetProducts"
+  ],
+  "Resource": "*"
+}
+```
+
+These are **read-only** calls with negligible cost. `pricing:GetProducts` is used for per-region rate lookups; if unavailable, the skill degrades to floor estimates flagged with ⚠️ rather than failing.
+
+## Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `cost_threshold` | $10 | Estimated cost the agent may proceed up to without asking; see note below |
+| `agent_space_region` | us-east-1 | Region where Agent Space is deployed |
+| `workload_region` | (auto-detect) | Region where workloads/log groups reside |
+
+The default `$10` threshold lets investigations proceed automatically when the estimate is under $10 and cancels, requesting explicit approval, when it is exceeded. Set it to `$0` for the most conservative mode, where the guardrail always shows the cost and cancels pending approval before running any paid query (this does not mean "only proceed when free"; it means nothing chargeable runs without the operator seeing the cost first). Adjust the value to match your team's risk tolerance.
+
+## How to Use
+
+1. Zip this skill directory:
+   ```bash
+   zip -r investigation-cost-guardrail.zip investigation-cost-guardrail/
+   ```
+2. Open the AWS DevOps Agent console
+3. Navigate to Settings → Add Skill → Upload Skill
+4. Select the `.zip` file and upload
+5. The skill is loaded on demand: the agent matches the skill's description against the task and chooses to load it, so it activates on investigation, debug, or root-cause requests
+
+> **Note on activation:** Skills are matched and loaded by the agent at its discretion, not auto-enforced by the platform, so activation depends on description matching and is not guaranteed for every investigation. To make the guardrail run reliably before any investigation, add an explicit instruction in your Agent Space configuration telling the agent to invoke this skill first, before executing investigation queries. You can also set your team's default threshold in that same instruction (for example, "use a cost threshold of $5 for all investigations"), which overrides the skill's built-in $10 default.
+
+## Author
+
+Ines Attia, Technical Account Manager, AWS Enterprise Support
+
+## License
+
+This project is licensed under the MIT-0 License. See the [LICENSE](LICENSE) file for details.

--- a/skills/investigation-cost-guardrail/SKILL.md
+++ b/skills/investigation-cost-guardrail/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: investigation-cost-guardrail
+description: Estimates the downstream AWS API cost of an incident investigation before the agent runs any CloudWatch Logs Insights, GetMetricData, X-Ray, or cross-region query, shows a per-step cost plan, and cancels if the estimate exceeds a threshold or no time window is provided. This skill applies ONLY to diagnosing a problem that has already happened (an incident, error, outage, alarm, latency spike, or failure) for example 'what happened', 'why is X down', 'look into this alarm', 'investigate the errors'. It does NOT apply to actions that create, change, deploy, scale, or configure resources (for example deploying a CDK or CloudFormation stack, or scaling a service), nor to architecture or Well-Architected reviews, cost or billing reports, inventory listing, or general how-to questions.
+version: 1.0.0
+author: inesttia-aws
+---
+
+# Investigation Cost Guardrail
+
+## Overview
+
+This skill acts as a cost guardrail for DevOps Agent investigations. Before pulling any data, it:
+
+1. Lists every resource the agent will query (CloudWatch Logs, Metrics, CloudTrail, X-Ray)
+2. Queries the actual stored bytes and IncomingBytes metric of relevant CloudWatch Log Groups
+3. Detects cross-region data transfer costs if the Agent Space and workload are in different regions
+4. Produces a visual investigation plan showing every step, its estimated data volume, and cost
+5. Makes a proceed/cancel decision based on total estimated cost vs. threshold (default: $10 — proceeds automatically when the estimate is under $10, cancels and requests operator approval when it is exceeded)
+6. If cancelled: tells the user exactly what information is missing to make it cheaper
+
+## Step 1: Parse the investigation request
+
+You MUST determine:
+- Which CloudWatch Log Groups are relevant to the investigation
+- Which CloudWatch Metrics namespaces/dimensions to query
+- Whether X-Ray or CloudTrail is needed
+- Whether a time window was explicitly provided by the user
+- **ALL AWS regions the investigation will touch** (see region rule below)
+
+### Region determination (MUST follow this order)
+
+DevOps Agent monitors resources across ALL regions in an account, and a single investigation can span multiple regions. You MUST derive each region from concrete evidence — never assume or default to us-east-1:
+
+1. **From the resource ARN** — extract the region segment (e.g., `arn:aws:logs:eu-west-1:...` → `eu-west-1`)
+2. **From the triggering alarm** — CloudWatch alarms are region-scoped; use the alarm's region
+3. **From the log group / metric** — the region where it is queried
+4. **From the topology** — if the investigation spans services in multiple regions, collect EVERY region involved, not just one
+
+You MUST build a list of all involved regions. For each region, Step 2 queries its log groups and its own Pricing API rate separately (rates differ by region).
+
+You MUST identify the Agent Space region (where DevOps Agent is deployed) to detect cross-region transfer in Step 3.
+
+### Agent Space region detection
+
+The Agent Space region is provided in the system context:
+- ARN: `arn:aws:aidevops:<REGION>:<ACCOUNT>:agentspace/<ID>`
+- Extract the region segment (e.g., `us-east-1`)
+
+If it is not available, ask the user:
+> "I need to know which region your DevOps Agent is deployed in to calculate cross-region data transfer costs. Which region is your Agent Space in?"
+
+**Common mistake:** assuming workload region = Agent Space region. Always verify both independently.
+
+You MUST NOT:
+- Invent or assume a time window if the user didn't provide one (e.g., do NOT default to "last 1 hour")
+- Assume or default any region for rate lookups — if a region cannot be derived from an ARN, alarm, or resource ID, use the worst-case/fallback estimate and ask the user to confirm the region
+
+When inputs are missing (region, log group, or time window), do NOT stop at open-ended questions. Still produce the Step 4 visual plan with worst-case or fallback estimates (flagged ⚠️) and an explicit decision, then list what the user should provide. A missing time window always results in 🚫 CANCEL.
+
+On failure: show the worst-case plan and CANCEL decision, then ask the user to clarify what service, resource, region, or time window is affected.
+
+## Step 2: Fetch actual data volume
+
+You MUST query real data. Do NOT estimate without API calls.
+
+**CRITICAL**: You MUST use the AWS Pricing API to get the correct per-unit rate for the workload region. Do NOT hardcode $0.005/GB — rates vary by region. See [references/pricing-reference.md](references/pricing-reference.md) for exact API calls and region prefix mapping. If the Pricing API fails, fall back to the floor estimates in that file and flag with ⚠️.
+
+**CRITICAL**: If a time window is provided (even a broad one like "last 60 days"), you MUST use Path A. Path B is ONLY for when no time window is provided at all.
+
+### CloudWatch Logs Insights cost
+
+#### Path A: Time window provided (any duration)
+
+You MUST query the IncomingBytes CloudWatch metric for the exact time window:
+
+```bash
+aws cloudwatch get-metric-statistics \
+  --namespace "AWS/Logs" \
+  --metric-name "IncomingBytes" \
+  --dimensions Name=LogGroupName,Value="<LOG_GROUP_NAME>" \
+  --start-time "<START>" \
+  --end-time "<END>" \
+  --period <WINDOW_SECONDS> \
+  --statistics Sum \
+  --region <workload_region>
+```
+
+Calculate: `scan_gb = Sum / 1e9` → `cost = scan_gb × regional_rate`  (use 1e9 = GB, matching AWS billing — NOT 1024³, which is GiB and under-counts ~7%)
+
+#### Path B: No time window provided
+
+You MUST query describe-log-groups to get total storedBytes (worst case):
+
+```bash
+aws logs describe-log-groups \
+  --log-group-name-prefix "<PREFIX>" \
+  --region <workload_region>
+```
+
+Calculate: `scan_gb = storedBytes / 1e9` → `cost = scan_gb × regional_rate`  (1e9 = GB, matching AWS billing)
+
+### CloudWatch GetMetricData cost
+
+You MUST count the number of metrics and periods the investigation would request:
+
+```
+metrics_cost = (num_metrics × num_periods) / 1000 × regional_rate
+```
+
+For example: 4 metrics × 60 periods = 240 metric requests → $0.0024
+
+### X-Ray cost (if applicable)
+
+If the investigation would scan X-Ray traces, you MUST estimate:
+
+```
+xray_cost = estimated_traces / 1,000,000 × regional_rate
+```
+
+If X-Ray is not configured or not relevant, show $0.00 in the visual plan.
+
+#### X-Ray trace count estimation
+
+To estimate trace count for a time window:
+
+```bash
+aws xray get-trace-summaries \
+  --start-time <START> \
+  --end-time <END> \
+  --region <workload_region>
+```
+
+**Preferred (precise):** paginate `get-trace-summaries` over the FULL window (follow `NextToken`) and sum `TracesProcessedCount`. This is the exact count of traces the investigation would scan — no extrapolation needed. Note: `get-trace-summaries` is itself a billable trace-fetch call, so this estimation has a small X-Ray cost of its own.
+
+**Fallback (only for very large windows, less precise):** query a representative sample window and extrapolate `total_traces = (sample_count / sample_minutes) × total_minutes`. Trace volume is bursty, so flag this with ⚠️: "Trace count extrapolated from sample — actual may vary." Prefer the longest sample you can afford (not 5 min) to reduce error.
+
+If X-Ray returns 0 traces, the service may not have tracing enabled — show $0.00 and note "X-Ray not configured or no traces in window".
+
+### CloudTrail cost (if applicable)
+
+**CloudTrail LookupEvents — FREE.** The standard `cloudtrail:LookupEvents` API (last 90 days of management events) has no cost. Investigations use only this — show it in the visual plan as `$0.00 — free` and do NOT estimate it.
+
+#### CloudTrail limitations (platform may block LookupEvents)
+
+⚠️ **Known issue:** the agent platform may block `cloudtrail:LookupEvents`. If this happens:
+
+1. Show it in the visual plan:
+   ```
+   ⚠️ CloudTrail LookupEvents — BLOCKED BY PLATFORM
+      → Cannot estimate CloudTrail activity
+      → "What changed?" analysis will be unavailable
+   ```
+2. Inform the user:
+   > "I won't be able to check what infrastructure changes occurred because CloudTrail access is blocked. The investigation will proceed without change analysis."
+3. Do NOT fail the entire cost estimation — `LookupEvents` is free anyway ($0.00), so a block has no cost impact.
+
+### CloudWatch Contributor Insights (if applicable)
+
+If the investigation would use Contributor Insights rules:
+
+```
+contributor_insights_cost = num_rules × (matching_events / 1000) × regional_rate
+```
+
+### CloudWatch Live Tail (if applicable)
+
+If the investigation would use Live Tail to stream logs in real time:
+
+```
+live_tail_cost = session_minutes × regional_rate
+```
+
+### Free APIs (include in visual plan with $0.00)
+
+The following APIs have no cost but you MUST still show them in the visual plan for transparency:
+- `CloudWatch Logs FilterLogEvents` — free
+- `CloudTrail LookupEvents` — free
+- `EC2/ECS/RDS Describe*` calls — free
+- `CloudWatch GetMetricStatistics` — negligible ($0.01 per 1,000 requests)
+
+### Fallback: Permission denied
+
+If any CLI command fails, fall back to 5 GB per log group as a conservative estimate. You MUST flag this in the visual plan with ⚠️:
+
+```
+⚠️ /aws/ecs/prod-api — ESTIMATED (no permission)
+   → Assumed: 5 GB │ Cost: $0.0250 (may be higher)
+```
+
+## Step 3: Calculate cross-region data transfer cost
+
+DevOps Agent's Agent Space is in one region, but the resources it investigates are often in other regions. Cross-region cost applies ONLY to the **result bytes returned** across regions — NOT the scanned volume. The returned size depends on the query type, so estimate `returned_data_gb` accordingly:
+
+```
+for each workload_region ≠ agent_space_region:
+    if aggregation/stats query (counts, group-by, summaries):
+        returned_data_gb ≈ small  (results are tiny — use ~1% of scan_gb, or a few MB cap)
+    elif raw-event / trace fetch (returns matching log lines or traces):
+        returned_data_gb ≈ up to 100% of the matched bytes  (use matched/returned bytes if known)
+    else (query type unknown):
+        returned_data_gb ≈ scan_gb × 0.15   # rough UPPER-BOUND heuristic — flag with ⚠️
+    data_transfer_cost += returned_data_gb × $0.02/GB
+```
+
+Prefer the actual returned-result size when the query type is known (aggregations return almost nothing; raw fetches can return a large share). The 0.15 factor is only a fallback when the query shape is unknown — label it ⚠️ as an upper-bound estimate, not a precise figure.
+
+If a region matches the Agent Space region: no transfer cost for that region.
+If all resources are in the Agent Space region: total data transfer cost = $0.00.
+
+## Step 4: Show the visual investigation plan
+
+You MUST present the visual plan to the user before the decision gate.
+
+**You MUST always render this plan and an explicit decision, even when required inputs are missing or AWS credentials are unavailable.** If you cannot query real data (no credentials, permission denied, or the region/log group is unknown), still produce the plan using worst-case `storedBytes` or the 5 GB-per-log-group fallback, flag those lines with ⚠️, and state the decision. Do NOT replace the plan with open-ended clarifying questions: show the plan and the decision first, then list what is missing. When no time window is provided, the decision is always 🚫 CANCEL (show the worst-case plan and say "CANCELLED — no time window").
+
+You MUST show:
+- Every step the agent would take (even if cost = $0)
+- Exact GB and exact cost per step
+- Running total, threshold, and decision
+- Cross-region transfer step with both regions labeled (if applicable)
+- ⚠️ flag on any fallback estimates
+
+See [references/example-output.md](references/example-output.md) for format examples.
+
+## Step 5: Decision gate
+
+You MUST apply these rules strictly:
+
+| Condition | Decision | Action |
+|-----------|----------|--------|
+| No time window provided | 🚫 CANCEL | Show worst-case cost, ask for time window |
+| Time window + cost < threshold (default $10) | ✅ PROCEED | Begin investigation |
+| Time window + cost ≥ threshold | 🚫 CANCEL | Show cost, ask for operator approval or a narrower scope |
+
+On CANCEL, you MUST:
+- Show the visual plan
+- List what's missing to make it cheaper
+- Stop completely — do NOT proceed with any investigation
+
+On PROCEED, you MUST:
+- Show the visual plan
+- State: "✅ PROCEEDING — Estimated cost: $X.XX (within $Y.YY threshold)"
+
+## Step 6: Cost reduction suggestions (on cancel)
+
+You MUST provide specific, actionable suggestions:
+
+| User can provide | How it reduces cost | Estimated savings |
+|-----------------|-------------------|-------------------|
+| Exact timestamp (± 5 min) | Scans 10 min instead of all stored data | ~90%+ |
+| Specific log group name | 1 group instead of N | Up to 90% |
+| Known error message | Free FilterLogEvents instead of Logs Insights | 100% of Logs Insights cost |
+| "Skip X-Ray" / "Skip CloudTrail" | Eliminates those cost components | Variable |
+| "Same region only" | No cross-region transfer | Eliminates DT cost |
+
+## Configuration
+
+### Cost threshold
+
+The skill uses a threshold to decide proceed/cancel. Default: `$10.00` — the agent proceeds automatically when the estimate is under the threshold and cancels (requesting approval) when it is exceeded.
+
+The user can set a custom threshold for the session by saying:
+- "Set cost threshold to $1.00"
+- "Auto-approve investigations under $0.50"
+- "Set threshold to $0" (most conservative — always cancel and require approval before any paid query)
+
+Remember it for the session:
+
+| Threshold | Behavior |
+|-----------|----------|
+| $0.00 | Always show plan, always require approval before any paid query (most conservative) |
+| $10.00 (default) | Auto-proceed if under $10, cancel and request approval if exceeded |
+| Custom | Auto-proceed if under, cancel if over |
+
+To reset: "Reset cost threshold to default".
+
+The operator can also set a persistent default in the Agent Space configuration instruction (e.g., "use a cost threshold of $5 for all investigations"), which overrides the built-in $10 default. A threshold the user states in the current conversation takes precedence for that session.
+
+## Calibration guidance
+
+You MUST NOT cancel or flag when:
+- An alarm-triggered investigation has a narrow window (± 30 min) and targets a single resource — this is expected to be low-cost; run the estimation and proceed if under threshold
+- The estimated cost is $0.00 because the log group has no data in the window — proceed, there's nothing to scan
+- The user explicitly says "proceed anyway" or "I approve this cost" — respect the operator's decision
+
+You MUST cancel when:
+- No time window is provided, regardless of how small the log groups appear
+- The estimated cost exceeds the threshold (default $10) — show the plan and cancel, requesting approval or a narrower scope
+- The investigation would scan > 100 GB — flag with ⚠️ even if under threshold
+
+"Cannot determine" is valid when:
+- Log groups are encrypted and DescribeLogGroups doesn't return storedBytes
+- IncomingBytes returns empty datapoints (log group may have no data in that window — cost is $0)
+
+## References
+
+- [Pricing Reference](references/pricing-reference.md) — exact per-unit costs for all APIs
+- [Example Output](references/example-output.md) — full visual plan examples for all decision paths
+- [CloudWatch Pricing](https://aws.amazon.com/cloudwatch/pricing/)
+- [AWS Data Transfer Pricing](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer)

--- a/skills/investigation-cost-guardrail/SKILL.md
+++ b/skills/investigation-cost-guardrail/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: investigation-cost-guardrail
 description: Estimates the downstream AWS API cost of an incident investigation before the agent runs any CloudWatch Logs Insights, GetMetricData, X-Ray, or cross-region query, shows a per-step cost plan, and cancels if the estimate exceeds a threshold or no time window is provided. This skill applies ONLY to diagnosing a problem that has already happened (an incident, error, outage, alarm, latency spike, or failure) for example 'what happened', 'why is X down', 'look into this alarm', 'investigate the errors'. It does NOT apply to actions that create, change, deploy, scale, or configure resources (for example deploying a CDK or CloudFormation stack, or scaling a service), nor to architecture or Well-Architected reviews, cost or billing reports, inventory listing, or general how-to questions.
-version: 1.0.0
-author: inesttia-aws
+metadata:
+  author: inesttia
+  version: "1.0.0"
+  aws-devops-agent-skills.agent-types: "Incident RCA"
+  aws-devops-agent-skills.aws-services: "Amazon CloudWatch, AWS X-Ray, AWS CloudTrail"
+  aws-devops-agent-skills.technical-domains: "Cost Optimization, Operations"
 ---
 
 # Investigation Cost Guardrail

--- a/skills/investigation-cost-guardrail/evals/benchmark.json
+++ b/skills/investigation-cost-guardrail/evals/benchmark.json
@@ -1,0 +1,1518 @@
+{
+  "skill_name": "investigation-cost-guardrail",
+  "skill_path": "Devops-Agent-Finops-Skills-main",
+  "eval_count": 12,
+  "runs_per_eval": 1,
+  "metadata": {
+    "timestamp": "2026-06-21T01:21:46Z"
+  },
+  "runs": [
+    {
+      "eval_id": 1,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 1,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions CloudWatch Logs or log groups",
+            "passed": true,
+            "evidence": "The output mentions 'log group name' as an example under 'Which service/resource?'",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a dollar cost estimate with at least 4 decimal places",
+            "passed": false,
+            "evidence": "No dollar cost estimate appears anywhere in the output. It only mentions 'cost-efficient' in passing.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled (mentions 'cancel' or 'cancelled')",
+            "passed": false,
+            "evidence": "The words 'cancel' or 'cancelled' do not appear anywhere in the output.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks the user to provide a time window or timestamp",
+            "passed": true,
+            "evidence": "The output explicitly asks 'Time window?' with examples like 'last 30 minutes', 'between 2pm and 3pm UTC today'.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output lists what information is missing to make it cheaper",
+            "passed": false,
+            "evidence": "The output lists what information is needed to proceed and mentions being 'cost-efficient', but does not explicitly frame the missing items as things needed 'to make it cheaper' - it frames them as required to proceed at all.",
+            "method": "llm",
+            "confidence": 0.55,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.4,
+        "summary": "With skill: 40% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 273,
+            "cache_read_input_tokens": 15409,
+            "cache_creation_input_tokens": 19587
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 13.71012220800003
+        },
+        "raw_output": "What would you like me to investigate? I need some details to proceed:\n\n- **What's the issue?** (e.g., an alarm firing, errors in a service, a deployment failure, latency spike)\n- **Which service/resource?** (e.g., log group name, service name, ARN)\n- **Which AWS region?**\n- **Time window?** (e.g., \"last 30 minutes\", \"between 2pm and 3pm UTC today\")\n\nThe more specific you can be, the more targeted (and cost-efficient) the investigation will be."
+      },
+      "without_skill": {
+        "eval_id": 1,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions CloudWatch Logs or log groups",
+            "passed": false,
+            "evidence": "The output makes no mention of CloudWatch Logs or log groups anywhere",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a dollar cost estimate with at least 4 decimal places",
+            "passed": false,
+            "evidence": "The output contains no dollar cost estimate at all",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled (mentions 'cancel' or 'cancelled')",
+            "passed": false,
+            "evidence": "The output does not mention 'cancel' or 'cancelled'; it asks for clarification instead",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks the user to provide a time window or timestamp",
+            "passed": false,
+            "evidence": "The output asks for clarification about what to investigate (file/URL/error, pipeline, codebase) but does not specifically ask for a time window or timestamp",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output lists what information is missing to make it cheaper",
+            "passed": false,
+            "evidence": "The output does not discuss costs or list information needed to make anything cheaper",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.0,
+        "summary": "Without skill: 0% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 1,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 257,
+            "cache_read_input_tokens": 30814,
+            "cache_creation_input_tokens": 31023
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 15.31261137499996
+        },
+        "raw_output": "Let me look at what's in the current working directory to understand what needs investigation.The working directory is empty. Could you clarify what you'd like me to investigate? For example:\n\n- A specific file, URL, or error?\n- A pipeline or deployment issue?\n- A codebase or repository?\n\nLet me know what to look into and I'll get started."
+      },
+      "delta_pass_rate": 0.4
+    },
+    {
+      "eval_id": 2,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 2,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions ECS or container-related log groups",
+            "passed": true,
+            "evidence": "Output mentions 'Scan ECS container logs' and 'CloudWatch Logs Insights' and references 'exact log groups to query' \u2014 refers to ECS/container-related log groups",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate in dollars",
+            "passed": true,
+            "evidence": "Output shows multiple dollar cost estimates: ~$0.025, ~$0.001, ~$0.0005, and a total of ~$0.05",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled because no time window was provided",
+            "passed": true,
+            "evidence": "Output explicitly states 'DECISION: CANCEL' with 'Reason: No time window provided'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks for an exact incident time or time window",
+            "passed": true,
+            "evidence": "Output lists 'Time window' as missing input with examples like 'last 30 minutes' and 'since 2026-06-21T14:00Z', and asks 'Could you provide these details? Even an approximate time window...'",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output suggests that providing a time window would reduce cost by 90% or more",
+            "passed": true,
+            "evidence": "Output explicitly states 'Scans only that window instead of all stored data \u2014 typically 90%+ savings'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 1.0,
+        "summary": "With skill: 100% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 1267,
+            "cache_read_input_tokens": 15409,
+            "cache_creation_input_tokens": 19600
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 34.38861833400006
+        },
+        "raw_output": "I'll run the investigation cost guardrail before pulling any data.\n\n## \ud83d\udccb Investigation Cost Estimation \u2014 ECS Service Failure\n\n### Inputs Identified\n\n| Input | Status |\n|-------|--------|\n| ECS Service / Cluster | \u274c Not provided |\n| Region | \u274c Not provided |\n| Time window | \u274c Not provided |\n| Failure type | \u274c Not specified |\n\n---\n\n### \ud83d\udd0d Estimated Investigation Plan (worst-case fallback)\n\nA typical ECS failure investigation would query:\n\n| # | Step | Resource | Est. Data | Est. Cost |\n|---|------|----------|-----------|-----------|\n| 1 | Query ECS service events | ECS DescribeServices | \u2014 | $0.00 (free) |\n| 2 | Query task stopped reasons | ECS DescribeTasks | \u2014 | $0.00 (free) |\n| 3 | Scan application logs | CloudWatch Logs Insights | \u26a0\ufe0f ~5 GB (fallback) | \u26a0\ufe0f ~$0.025 |\n| 4 | Scan ECS container logs | CloudWatch Logs Insights | \u26a0\ufe0f ~5 GB (fallback) | \u26a0\ufe0f ~$0.025 |\n| 5 | Check service metrics | CloudWatch GetMetricData | ~100 requests | ~$0.001 |\n| 6 | Check ALB/target group health | CloudWatch GetMetricData | ~50 requests | ~$0.0005 |\n| 7 | Cross-region data transfer | Unknown | \u26a0\ufe0f Unknown | \u26a0\ufe0f Unknown |\n\n| | |\n|---|---|\n| **Estimated Total** | \u26a0\ufe0f ~$0.05 (highly uncertain \u2014 no real data) |\n| **Threshold** | $10.00 |\n\n---\n\n### \ud83d\udeab DECISION: CANCEL\n\n**Reason:** No time window provided. Without a time window, the investigation could scan ALL stored log data, resulting in unpredictable costs.\n\n---\n\n### What I need to proceed\n\n| # | Missing Input | How it reduces cost |\n|---|---------------|-------------------|\n| 1 | **Time window** (e.g., \"last 30 minutes\", \"since 2026-06-21T14:00Z\") | Scans only that window instead of all stored data \u2014 typically 90%+ savings |\n| 2 | **ECS service name and cluster** (or ARN) | Identifies the exact log groups to query |\n| 3 | **AWS region** | Required for accurate pricing and to detect cross-region transfer costs |\n| 4 | **Failure symptoms** (tasks crashing, health checks failing, deployment stuck, OOM, etc.) | Narrows which logs/metrics to quer"
+      },
+      "without_skill": {
+        "eval_id": 2,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions ECS or container-related log groups",
+            "passed": false,
+            "evidence": "The output mentions 'ECS service' but does not mention any log groups or container-related log groups",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate in dollars",
+            "passed": false,
+            "evidence": "No cost estimate in dollars appears anywhere in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled because no time window was provided",
+            "passed": false,
+            "evidence": "The investigation stalled due to lack of service name/cluster/account context, not because no time window was provided",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks for an exact incident time or time window",
+            "passed": false,
+            "evidence": "The output asks for service name, location, and symptoms, but does not specifically ask for an incident time or time window",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output suggests that providing a time window would reduce cost by 90% or more",
+            "passed": false,
+            "evidence": "No mention of cost reduction percentages or time window cost savings anywhere in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.0,
+        "summary": "Without skill: 0% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 3,
+          "token_counts": {
+            "input_tokens": 5,
+            "output_tokens": 590,
+            "cache_read_input_tokens": 77264,
+            "cache_creation_input_tokens": 15987
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 24.762574792000123
+        },
+        "raw_output": "I'll investigate the ECS service failure. Let me start by exploring what's in the current working directory to understand the context.The working directory is empty. I need more context to investigate the ECS service failure. Let me check if there's a Brazil workspace or any relevant project context elsewhere.I don't have enough context to investigate the ECS service failure. I need more information from you:\n\n1. **Which ECS service?** \u2014 Do you have a service name, cluster name, or pipeline name?\n2. **Where is it?** \u2014 Which AWS account/region, or which pipeline is deploying it?\n3. **What symptoms are you seeing?** \u2014 Tasks failing to start, health check failures, deployment stuck, etc.?\n\nIf you have a pipeline URL, a SIM ticket, or a service name, I can use internal tools to look into it. Alternatively, if there's a workspace or package related to this service, point me to it and I can check the code/configuration."
+      },
+      "delta_pass_rate": 1.0
+    },
+    {
+      "eval_id": 3,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 3,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions Lambda log groups",
+            "passed": true,
+            "evidence": "Output explicitly mentions '/aws/lambda/*' log groups multiple times, including 'Step 3: CloudWatch Logs Insights \u2014 Scan Lambda log groups' and 'Log groups: `/aws/lambda/*`'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost calculation based on data volume (GB) multiplied by $0.005",
+            "passed": true,
+            "evidence": "Output shows '5 GB per log group \u00d7 ~5 groups = 25 GB' with 'Rate: $0.005/GB' resulting in 'Cost: $0.1250' \u2014 clearly data volume multiplied by $0.005",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The estimated cost exceeds the threshold",
+            "passed": false,
+            "evidence": "Output states 'TOTAL ESTIMATED COST: ~$0.13' and 'THRESHOLD: $10.00' with 'DECISION: \u2705 PROCEED (estimate well under threshold)' \u2014 cost does NOT exceed threshold",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled due to cost exceeding threshold",
+            "passed": false,
+            "evidence": "Output says 'DECISION: \u2705 PROCEED' \u2014 investigation is not cancelled due to cost. It cannot proceed only because AWS credentials are not configured, not because of cost",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output suggests narrowing the time window (e.g., last 1 hour or last 15 minutes)",
+            "passed": false,
+            "evidence": "Output suggests configuring AWS credentials, specifying Lambda functions, and confirming region \u2014 but never suggests narrowing the time window to reduce cost",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.4,
+        "summary": "With skill: 40% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 3,
+          "token_counts": {
+            "input_tokens": 5,
+            "output_tokens": 2945,
+            "cache_read_input_tokens": 85779,
+            "cache_creation_input_tokens": 22012
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 71.71683666700028
+        },
+        "raw_output": "I'll run the investigation cost guardrail before pulling any data. Let me check what's available and estimate the cost.I have no AWS credentials configured, so I cannot query real data volumes. However, I can still produce the investigation cost plan per the guardrail. Let me identify the relevant resources and present the visual plan with fallback estimates.\n\n## Investigation Cost Guardrail \u2014 Lambda Errors (Last 24 Hours)\n\n### Inputs Determined\n\n| Input | Value | Source |\n|-------|-------|--------|\n| **Time window** | Last 24 hours (2026-06-20T00:00Z \u2192 2026-06-21T00:00Z) | User-provided |\n| **Workload region** | us-west-2 | AWS config (`AWS_DEFAULT_REGION`) |\n| **Agent Space region** | Unknown | Not available in context |\n| **Log groups** | `/aws/lambda/*` (unknown specific functions) | Inferred from \"Lambda errors\" |\n\n### Resources I Cannot Query (No Credentials)\n\n- Cannot run `aws cloudwatch get-metric-statistics` for IncomingBytes\n- Cannot run `aws logs describe-log-groups` for storedBytes\n- Cannot run `aws pricing get-products` for regional rate\n\n---\n\n### Visual Investigation Plan\n\n```\n\u250c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2510\n\u2502  INVESTIGATION: Lambda Errors \u2014 Last 24 Hours                               \u2502\n\u2502  Region: us-west-2                                                          \u2502\n\u2502  Window: 2026-06-20T00:00Z \u2192 2026-06-21T00:00Z (24h)                       \u2502\n\u251c\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2524\n\u2502                                                                             \u2502\n\u2502  Step 1: Describe Lambda functions                                          \u2502\n\u2502     \u2192 aws lambda list-functions                                             \u2502\n\u2502     \u2192 Cost: $0.00 \u2014 free                                                    \u2502\n\u2502                                                                             \u2502\n\u2502  Step 2: CloudWatch Metrics \u2014 Lambda Error/Invocation metrics               \u2502\n\u2502     \u2192 GetMe"
+      },
+      "without_skill": {
+        "eval_id": 3,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions Lambda log groups",
+            "passed": false,
+            "evidence": "Output mentions 'CloudWatch Logs for Lambda errors' but does not specifically mention Lambda log groups as distinct entities",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost calculation based on data volume (GB) multiplied by $0.005",
+            "passed": false,
+            "evidence": "No cost calculation, no mention of GB, no $0.005 price anywhere in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The estimated cost exceeds the threshold",
+            "passed": false,
+            "evidence": "No estimated cost or threshold is mentioned anywhere in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled due to cost exceeding threshold",
+            "passed": false,
+            "evidence": "Investigation stopped due to missing AWS credentials, not due to cost exceeding a threshold",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output suggests narrowing the time window (e.g., last 1 hour or last 15 minutes)",
+            "passed": false,
+            "evidence": "Output does not suggest narrowing the time window; it only asks about scope (specific function vs all functions)",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.0,
+        "summary": "Without skill: 0% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 2,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 576,
+            "cache_read_input_tokens": 46221,
+            "cache_creation_input_tokens": 15693
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 24.960289541999828
+        },
+        "raw_output": "I'll investigate Lambda errors from the last 24 hours. Let me first check what AWS credentials and profiles are available.No AWS credentials are currently configured, and there's no `~/.aws/config` file present. I need a few things to proceed:\n\n1. **AWS credentials** \u2014 You'll need to authenticate first (e.g., `aws login` or configure a profile). Do you have a specific profile or account you'd like to use? I'd prefer ReadOnly credentials for this investigation.\n\n2. **Scope** \u2014 Should I look at:\n   - A specific Lambda function?\n   - All Lambda functions in a particular region/account?\n   - Functions related to a specific service or pipeline?\n\nOnce you're authenticated, I can query CloudWatch Logs for Lambda errors (invocation errors, timeouts, OOM, etc.) from the last 24 hours and summarize the findings."
+      },
+      "delta_pass_rate": 0.4
+    },
+    {
+      "eval_id": 4,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 4,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output uses IncomingBytes or mentions querying actual data volume for the time window",
+            "passed": false,
+            "evidence": "The output does not mention IncomingBytes or query actual data volume. It explicitly states 'No credentials \u2014 using 5 GB fallback' which is a hardcoded estimate, not queried from the actual time window.",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate that is very small (sub-cent)",
+            "passed": false,
+            "evidence": "The running total is ~$0.026 (about 2.6 cents) and the output says '~$0.03'. Sub-cent means less than $0.01. The estimate is small but not sub-cent.",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output includes a visual plan or step-by-step breakdown of what the agent will do",
+            "passed": true,
+            "evidence": "The output contains a clearly labeled 'Visual Investigation Plan' table with 5 numbered steps showing what the agent will do, including resources to query and methods.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "Each step in the plan shows its estimated cost",
+            "passed": true,
+            "evidence": "Every step in the plan table has an 'Est. Cost' column filled in: Step 1 ($0.0250), Step 2 ($0.0002), Step 3 ($0.00 free), Step 4 ($0.00 free), Step 5 ($0.0010).",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.5,
+        "summary": "With skill: 50% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 2,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 2509,
+            "cache_read_input_tokens": 50431,
+            "cache_creation_input_tokens": 19929
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 60.53862799999979
+        },
+        "raw_output": "I'll investigate the ECS crash, but first I need to run the cost guardrail to estimate query costs before pulling any data. Let me check your AWS configuration and identify the relevant resources.I don't have AWS credentials configured, but I'll still produce the cost estimation plan per the investigation guardrail. Since I have a time window (5 minutes), I'll use fallback estimates.\n\n---\n\n## Investigation Cost Estimate \u2014 ECS Crash at 14:15 UTC\n\n**Time window:** 2026-06-21 14:10:00 UTC \u2192 2026-06-21 14:15:00 UTC (5 minutes)\n\n---\n\n### \ud83d\udccb Visual Investigation Plan\n\n| # | Step | Resource | Est. Data | Est. Cost | Notes |\n|---|------|----------|-----------|-----------|-------|\n| 1 | Query ECS application logs | \u26a0\ufe0f `/aws/ecs/*` (unknown log group) | \u26a0\ufe0f 5 GB (fallback) | \u26a0\ufe0f $0.0250 | No credentials \u2014 using 5 GB fallback |\n| 2 | Query ECS container metrics | `AWS/ECS` namespace (CPUUtilization, MemoryUtilization, RunningTaskCount, HealthCheckStatus) | ~20 metric requests | $0.0002 | 4 metrics \u00d7 5 periods |\n| 3 | CloudTrail LookupEvents | Management events (task stops, service updates) | \u2014 | $0.00 \u2014 free | |\n| 4 | FilterLogEvents (crash details) | \u26a0\ufe0f Same log group | \u2014 | $0.00 \u2014 free | |\n| 5 | Cross-region data transfer | \u26a0\ufe0f Unknown regions | \u26a0\ufe0f ~0.05 GB returned | \u26a0\ufe0f $0.0010 | Assuming aggregation query, small result set |\n\n---\n\n**Running total: \u26a0\ufe0f ~$0.026** (worst-case with fallbacks)  \n**Threshold: $10.00**  \n**Decision: \u2705 PROCEED \u2014 Estimated cost $0.03 is well within $10.00 threshold**\n\n---\n\nHowever, **I cannot execute the investigation** because AWS credentials are not configured. To proceed, I need:\n\n| Missing | How to provide |\n|---------|---------------|\n| **AWS credentials** | Run `aws login` or configure `~/.aws/config` with a profile |\n| **Region** | Which region is your ECS service in? (e.g., `us-east-1`, `eu-west-1`) |\n| **Log group name** | Exact ECS log group (e.g., `/aws/ecs/prod-api`, `/ecs/my-service`) |\n| **ECS cluster/service name** | To query the right me"
+      },
+      "without_skill": {
+        "eval_id": 4,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output uses IncomingBytes or mentions querying actual data volume for the time window",
+            "passed": false,
+            "evidence": "The output does not mention IncomingBytes or any data volume querying. It only asks clarifying questions about cluster, region, and profile.",
+            "method": "llm",
+            "confidence": 0.97,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate that is very small (sub-cent)",
+            "passed": false,
+            "evidence": "The output contains no cost estimate of any kind. It is entirely composed of clarifying questions.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output includes a visual plan or step-by-step breakdown of what the agent will do",
+            "passed": false,
+            "evidence": "The output has numbered items (1-3) but these are clarifying questions asking for context, not a plan or step-by-step breakdown of what the agent will do.",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          },
+          {
+            "text": "Each step in the plan shows its estimated cost",
+            "passed": false,
+            "evidence": "There is no plan with steps, and no estimated costs are shown anywhere in the output.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.0,
+        "summary": "Without skill: 0% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 1,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 648,
+            "cache_read_input_tokens": 46242,
+            "cache_creation_input_tokens": 15654
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 22.19449850000001
+        },
+        "raw_output": "I need a few more details to investigate the ECS crash. I don't have enough context to identify which service is affected.I need more information to investigate the ECS crash:\n\n1. **Which ECS cluster/service?** \u2014 cluster name, service name\n2. **AWS region?** \u2014 e.g., us-east-1, us-west-2\n3. **AWS profile/account?** \u2014 which credentials or profile should I use (preferably ReadOnly)\n\nWithout these, I can't query the right resources. Could you provide the service details?"
+      },
+      "delta_pass_rate": 0.5
+    },
+    {
+      "eval_id": 5,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 5,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions cross-region or data transfer",
+            "passed": true,
+            "evidence": "Output explicitly mentions 'Cross-region transfer | Yes (eu-west-1 \u2192 us-east-1)' and has a dedicated row for 'Cross-region data transfer'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output includes a data transfer cost component ($0.02/GB or similar)",
+            "passed": true,
+            "evidence": "Output includes 'Fallback: scan_gb \u00d7 0.15 \u00d7 $0.02' showing the $0.02/GB rate, and a total cross-region transfer cost of $0.045",
+            "method": "llm",
+            "confidence": 0.97,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions both us-east-1 and eu-west-1",
+            "passed": true,
+            "evidence": "Output explicitly lists 'Workload region | eu-west-1' and 'Agent Space region | us-east-1' in the configuration table, plus 'eu-west-1 \u2192 us-east-1' references",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled (no time window provided)",
+            "passed": true,
+            "evidence": "Output has '\ud83d\udeab DECISION: CANCEL' with 'Reason: No time window provided.' explicitly stated",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 1.0,
+        "summary": "With skill: 100% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 4,
+          "token_counts": {
+            "input_tokens": 6,
+            "output_tokens": 2193,
+            "cache_read_input_tokens": 121462,
+            "cache_creation_input_tokens": 22228
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 55.837588291999964
+        },
+        "raw_output": "I'll investigate the RDS issue in eu-west-1, but first I need to run the cost guardrail. Let me query for RDS-related log groups and pricing in that region.No AWS credentials are available. I'll still produce the cost estimation plan using fallback estimates as required by the guardrail.\n\nLet me also check the pricing reference for eu-west-1 rates.Now I have all the information I need to produce the visual investigation plan. Here's the cost estimation:\n\n---\n\n## \ud83d\udd0d Investigation Cost Estimation \u2014 RDS Issue (eu-west-1)\n\n### Configuration\n| Parameter | Value |\n|-----------|-------|\n| Workload region | `eu-west-1` |\n| Agent Space region | `us-east-1` |\n| Cross-region transfer | **Yes** (eu-west-1 \u2192 us-east-1) |\n| Time window | **Not provided** |\n| Cost threshold | $10.00 (default) |\n\n---\n\n### \ud83d\udccb Visual Investigation Plan\n\n| # | Step | Data Source | Est. Data | Est. Cost | Notes |\n|---|------|-------------|-----------|-----------|-------|\n| 1 | Describe RDS instances | `rds:DescribeDBInstances` | \u2014 | $0.00 | Free API |\n| 2 | Describe RDS events | `rds:DescribeEvents` | \u2014 | $0.00 | Free API |\n| 3 | Query RDS error logs | CloudWatch Logs Insights (`/aws/rds/*`) | \u26a0\ufe0f 5 GB per log group (fallback \u2014 no credentials) | \u26a0\ufe0f $0.0250/group | Fallback: $0.005/GB \u00d7 5 GB |\n| 4 | Query RDS slow query logs | CloudWatch Logs Insights (`/aws/rds/*/slowquery`) | \u26a0\ufe0f 5 GB (fallback) | \u26a0\ufe0f $0.0250 | Fallback estimate |\n| 5 | Query RDS general/audit logs | CloudWatch Logs Insights (`/aws/rds/*/audit`) | \u26a0\ufe0f 5 GB (fallback) | \u26a0\ufe0f $0.0250 | Fallback estimate |\n| 6 | CloudWatch RDS metrics | `GetMetricData` (~10 metrics \u00d7 60 periods) | 600 requests | $0.006 | CPU, connections, IOPS, freeable mem, etc. |\n| 7 | CloudTrail \u2014 recent changes | `LookupEvents` | \u2014 | $0.00 | Free API |\n| 8 | Cross-region data transfer | Results returned eu-west-1 \u2192 us-east-1 | \u26a0\ufe0f ~2.25 GB (15% of ~15 GB scan, upper bound) | \u26a0\ufe0f $0.045 | Fallback: scan_gb \u00d7 0.15 \u00d7 $0.02 |\n\n---\n\n### \u26a0\ufe0f Worst-case totals (assuming 3 RDS log grou"
+      },
+      "without_skill": {
+        "eval_id": 5,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions cross-region or data transfer",
+            "passed": true,
+            "evidence": "Output mentions 'Cross-region concern' and asks about 'replication or connectivity between your us-east-1 agent space and an RDS in eu-west-1', but does not mention 'data transfer' specifically",
+            "method": "llm",
+            "confidence": 0.75,
+            "uncertain": false
+          },
+          {
+            "text": "The output includes a data transfer cost component ($0.02/GB or similar)",
+            "passed": false,
+            "evidence": "No mention of any cost, pricing, or $/GB anywhere in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions both us-east-1 and eu-west-1",
+            "passed": true,
+            "evidence": "Output explicitly states 'connectivity between your us-east-1 agent space and an RDS in eu-west-1'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled (no time window provided)",
+            "passed": false,
+            "evidence": "The output does not say the investigation is cancelled. It asks for more context (ticket ID, account ID, service/alarm name, cross-region concern) to continue, but never mentions a time window requirement or cancellation",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.5,
+        "summary": "Without skill: 50% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 7,
+          "token_counts": {
+            "input_tokens": 66,
+            "output_tokens": 2184,
+            "cache_read_input_tokens": 201737,
+            "cache_creation_input_tokens": 29830
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 62.62889116700035
+        },
+        "raw_output": "I'll investigate the RDS issue in eu-west-1. Let me first load the relevant tools to check for incidents and alarms.I'll search for recent RDS-related tickets in eu-west-1 to understand the issue.The broad search returned mostly internal RDS operational tickets. Let me narrow this down \u2014 I need to understand your team context better. Let me search for tickets more relevant to you.I can see your resolver groups but need more context to narrow down the specific RDS issue. Let me search for recent high-severity RDS tickets in eu-west-1 and also check your groups for relevant tickets.I found high-severity RDS tickets in eu-west-1, but none are assigned to your resolver groups. I need a bit more context to narrow this down:I found high-severity RDS tickets in eu-west-1, but none are in your resolver groups. The top results are internal RDS operational tickets (patch deadline exceeded, telemetry gaps, etc.) \u2014 likely not what you're looking for.\n\nCould you provide more context so I can pinpoint the right issue?\n\n- **Ticket ID** \u2014 if you have a specific SIM-T ticket number\n- **Account ID or instance name** \u2014 the RDS resource you're concerned about\n- **Service/alarm name** \u2014 what's alerting you to the problem\n- **Cross-region concern** \u2014 is this about replication or connectivity between your us-east-1 agent space and an RDS in eu-west-1?\n\nAny of these will help me narrow the search significantly."
+      },
+      "delta_pass_rate": 0.5
+    },
+    {
+      "eval_id": 6,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 6,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions the Lambda function or /aws/lambda/ log group",
+            "passed": true,
+            "evidence": "Output explicitly mentions 'Lambda `data-processor`' multiple times and the log group '/aws/lambda/data-processor'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions FilterLogEvents as a free alternative to Logs Insights",
+            "passed": true,
+            "evidence": "Output lists FilterLogEvents with cost $0.0000 and '(free API)' alongside Logs Insights at $0.0250, implicitly presenting it as a cheaper/free option, though it doesn't explicitly use the word 'alternative'",
+            "method": "llm",
+            "confidence": 0.75,
+            "uncertain": false
+          },
+          {
+            "text": "The output acknowledges that providing the exact error message enables cheaper investigation",
+            "passed": false,
+            "evidence": "The output uses the error message 'NullPointerException' in the FilterLogEvents step but never explicitly states that having the exact error message enables a cheaper investigation path",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.6666666666666666,
+        "summary": "With skill: 67% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 5,
+          "token_counts": {
+            "input_tokens": 5,
+            "output_tokens": 2983,
+            "cache_read_input_tokens": 90079,
+            "cache_creation_input_tokens": 24557
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 68.0241340409998
+        },
+        "raw_output": "I'll investigate the NullPointerException in the `data-processor` Lambda, but first I need to run the cost estimation for this investigation per the cost guardrail. Let me check the relevant details.I need to determine the region and estimate costs before proceeding. Let me check for available AWS credentials and the Lambda's log group.I have the investigation parameters. Let me produce the cost estimation plan.\n\n**Investigation details:**\n- **Target:** Lambda `data-processor` \u2014 NullPointerException\n- **Time window:** Last 10 minutes (provided)\n- **Region:** us-west-2 (from `AWS_REGION` environment variable)\n- **Log group:** `/aws/lambda/data-processor`\n\nHowever, **no AWS credentials are available** \u2014 I cannot query actual data volumes via the Pricing API or CloudWatch. I'll use the 5 GB/log-group fallback (conservative for a 10-minute window).\n\n---\n\n```\n\ud83d\udccb INVESTIGATION COST ESTIMATE\n\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\nTarget:        NullPointerException in Lambda \"data-processor\"\nTime Window:   Last 10 minutes (~2026-06-21T<now-10m> \u2192 now)\nRegion:        us-west-2\nAgent Space:   Unknown (assuming same region \u2014 no transfer)\nThreshold:     $10.00 (default)\n\nStep                                        Data        Cost\n\u26a0\ufe0f Logs Insights  /aws/lambda/data-processor  5 GB        $0.0250\n   (ESTIMATED \u2014 no credentials to query actual IncomingBytes)\nGetMetricData  4 metrics \u00d7 10 periods       40 req      $0.0004\n   (Errors, Duration, Invocations, Throttles)\nX-Ray traces                                unknown     $0.0000\n   (cannot determine \u2014 no credentials)\nCloudTrail LookupEvents                     N/A         $0.0000\n   (free API)\nFilterLogEvents (NullPointerException)      N/A         $0.0000\n   (free API)\n\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\nTOTAL ESTIMATED COST: $0.0254\n\n\u26a0\ufe0f Limitations:\n\u2022 No AWS credentials available \u2014 5 GB is a conservative fallback;\n  actual 10-min ingestion for a Lambda is likely < 0.5 GB\n\u2022 Pricing ra"
+      },
+      "without_skill": {
+        "eval_id": 6,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions the Lambda function or /aws/lambda/ log group",
+            "passed": true,
+            "evidence": "The output mentions 'data-processor Lambda function' and 'data-processor Lambda' multiple times",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions FilterLogEvents as a free alternative to Logs Insights",
+            "passed": false,
+            "evidence": "The output does not mention FilterLogEvents anywhere; it only references CloudWatch Logs generally",
+            "method": "llm",
+            "confidence": 0.97,
+            "uncertain": false
+          },
+          {
+            "text": "The output acknowledges that providing the exact error message enables cheaper investigation",
+            "passed": false,
+            "evidence": "The output asks for the stack trace but does not frame it in terms of enabling cheaper investigation or cost savings",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.3333333333333333,
+        "summary": "Without skill: 33% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 2,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 512,
+            "cache_read_input_tokens": 46239,
+            "cache_creation_input_tokens": 15705
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 21.834588375000294
+        },
+        "raw_output": "I'll investigate the NullPointerException in the `data-processor` Lambda function. Let me check the workspace and look at recent logs.No AWS credentials are configured in this environment, and the working directory is empty. To debug the NullPointerException in your `data-processor` Lambda, I need a few things:\n\n1. **AWS access** \u2014 Run `aws login` or configure credentials/profiles so I can query CloudWatch Logs for the function.\n2. **Source code** \u2014 Is the Lambda source in a Brazil package? If so, let me know the package name and I can pull it into a workspace, or point me to where the code lives.\n\nAlternatively, if you can share:\n- The stack trace from the error (e.g., from the Lambda console or CloudWatch)\n- The Lambda's source location (package name, repo, or local path)\n\nI can start diagnosing the root cause from the code side while we sort out log access."
+      },
+      "delta_pass_rate": 0.3333333333333333
+    },
+    {
+      "eval_id": 7,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 7,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates (does not ignore the prompt)",
+            "passed": true,
+            "evidence": "The output engages directly with the 502 error investigation topic, asking clarifying questions to proceed, indicating the skill activated.",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions API Gateway or related log groups",
+            "passed": true,
+            "evidence": "The output explicitly mentions 'API Gateway' multiple times (e.g., '502 errors on your API Gateway', 'Which API Gateway?').",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled due to missing time window",
+            "passed": false,
+            "evidence": "The investigation is not cancelled; it is paused pending more information. The output says 'I'll need at least a rough window before proceeding' \u2014 this is a request for clarification, not a cancellation.",
+            "method": "llm",
+            "confidence": 0.8,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks when the 502 errors started",
+            "passed": true,
+            "evidence": "The output explicitly asks 'When did the 502s start?' with example time windows.",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.75,
+        "summary": "With skill: 75% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 580,
+            "cache_read_input_tokens": 15409,
+            "cache_creation_input_tokens": 19601
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 22.52939804200014
+        },
+        "raw_output": "I'd like to help investigate the 502 errors on your API Gateway. Before I pull any data, I need to estimate the cost of the investigation queries.\n\nTo build a cost plan, I need a few details:\n\n1. **Which API Gateway?** \u2014 the API ID, name, or ARN (this also tells me the region)\n2. **When did the 502s start?** \u2014 a time window (e.g., \"last 30 minutes\", \"since 2026-06-21T14:00Z\") is required to scope the log scan cost\n3. **Which region?** \u2014 if not obvious from an ARN\n\nWithout a time window, I'd have to scan all stored logs (which can be expensive), so I'll need at least a rough window before proceeding. Do you have these details?"
+      },
+      "without_skill": {
+        "eval_id": 7,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates (does not ignore the prompt)",
+            "passed": true,
+            "evidence": "The output provides a detailed response about 502 errors from API Gateway with troubleshooting steps, clearly indicating the skill activated",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions API Gateway or related log groups",
+            "passed": true,
+            "evidence": "Output explicitly mentions 'API Gateway' in the first sentence and 'CloudWatch Logs' in the follow-up questions",
+            "method": "llm",
+            "confidence": 0.97,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled due to missing time window",
+            "passed": false,
+            "evidence": "The output does not cancel any investigation; instead it provides troubleshooting guidance and asks follow-up questions to continue helping",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks when the 502 errors started",
+            "passed": false,
+            "evidence": "The output asks 'Is this sudden (was working before) or a new deployment?' which relates to timing but does not explicitly ask when the 502 errors started or request a specific time window",
+            "method": "llm",
+            "confidence": 0.55,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.5,
+        "summary": "Without skill: 50% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 423,
+            "cache_read_input_tokens": 15404,
+            "cache_creation_input_tokens": 15422
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 17.507494875000248
+        },
+        "raw_output": "A 502 from API Gateway means it got an invalid or no response from your backend integration. The most common causes:\n\n1. **Lambda timeout or crash** \u2014 your function is hitting its timeout limit, throwing an unhandled exception, or returning a malformed response (missing `statusCode`, wrong body format)\n2. **Integration response format** \u2014 Lambda proxy integrations require a specific response shape:\n   ```json\n   { \"statusCode\": 200, \"headers\": {...}, \"body\": \"string\" }\n   ```\n3. **VPC/network issues** \u2014 if your Lambda is in a VPC, it may have lost connectivity to the backend (NAT gateway, security group, or subnet misconfiguration)\n4. **Backend service down** \u2014 for HTTP integrations, the upstream server is unreachable or returning garbage\n\nTo help narrow it down:\n\n- What's your backend integration \u2014 Lambda, HTTP endpoint, or something else?\n- Is this sudden (was working before) or a new deployment?\n- Do you see anything in CloudWatch Logs for the integration target?\n\nIf you have a pipeline or deployment that might have triggered this, I can help investigate that as well."
+      },
+      "delta_pass_rate": 0.25
+    },
+    {
+      "eval_id": 8,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 8,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on the 'look into' phrase",
+            "passed": true,
+            "evidence": "The output shows investigation behavior consistent with a skill activation, but there's no explicit mention of 'look into' as a trigger phrase or confirmation of skill activation mechanics in the output itself",
+            "method": "llm",
+            "confidence": 0.4,
+            "uncertain": true
+          },
+          {
+            "text": "The output mentions EKS or Kubernetes-related log groups or metrics",
+            "passed": true,
+            "evidence": "Output explicitly mentions EKS-related log groups: '/aws/eks/<cluster>/cluster' and '/aws/containerinsights/<cluster>/performance', plus 'EKS control plane logs' and 'Container Insights logs'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output lists CloudWatch GetMetricData as one of the resources to query",
+            "passed": true,
+            "evidence": "Step 3 in the investigation table explicitly lists 'CloudWatch GetMetricData' as the data source for querying CPU metrics",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled",
+            "passed": true,
+            "evidence": "Output explicitly states 'DECISION: CANCELLED \u2014 No time window provided'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks for a specific time window",
+            "passed": true,
+            "evidence": "Output asks 'Time window (most critical) \u2014 When did the alarm fire?' and concludes with 'Could you provide the alarm time window and cluster details?'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 1.0,
+        "summary": "With skill: 100% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 2,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 1909,
+            "cache_read_input_tokens": 50422,
+            "cache_creation_input_tokens": 19930
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 50.0864343330004
+        },
+        "raw_output": "I'll investigate the high CPU alarm on your production EKS cluster. First, I need to run the investigation cost guardrail to estimate query costs before pulling any data.\n\nLet me check your AWS configuration to identify the cluster and region.I don't have AWS credentials configured, and I'm missing several critical details. Per the investigation cost guardrail, I must present a cost estimate before querying any data. Here's the worst-case plan based on what I can determine:\n\n---\n\n## \ud83d\udd0d Investigation Cost Estimate \u2014 EKS High CPU Alarm\n\n### Missing Information\n| Input | Status |\n|-------|--------|\n| Time window | \u274c **NOT PROVIDED** |\n| Cluster name | \u274c Unknown |\n| Region | \u274c Unknown (no ARN or alarm ID provided) |\n| AWS credentials | \u274c Not configured |\n| Agent Space region | \u274c Unknown |\n\n### Planned Investigation Steps\n\n| # | Step | Data Source | Est. Volume | Est. Cost |\n|---|------|-------------|-------------|-----------|\n| 1 | Query EKS control plane logs | CloudWatch Logs Insights (`/aws/eks/<cluster>/cluster`) | \u26a0\ufe0f 5 GB (fallback) | \u26a0\ufe0f ~$0.025 |\n| 2 | Query Container Insights logs | CloudWatch Logs Insights (`/aws/containerinsights/<cluster>/performance`) | \u26a0\ufe0f 5 GB (fallback) | \u26a0\ufe0f ~$0.025 |\n| 3 | Query CPU metrics (node/pod level) | CloudWatch GetMetricData | ~500 requests | ~$0.005 |\n| 4 | Check recent deployments/changes | CloudTrail LookupEvents | N/A | $0.00 (free) |\n| 5 | Check X-Ray traces (if enabled) | X-Ray GetTraceSummaries | Unknown | \u26a0\ufe0f TBD |\n| 6 | Cross-region data transfer | Network | Unknown | \u26a0\ufe0f TBD |\n\n**Estimated total (worst-case): \u26a0\ufe0f ~$0.06+ (cannot bound without time window)**\n\n---\n\n## \ud83d\udeab DECISION: CANCELLED \u2014 No time window provided\n\nWithout a time window, the investigation could scan ALL stored log data, making cost unbounded.\n\n---\n\n### What I need to proceed:\n\n1. **Time window** (most critical) \u2014 When did the alarm fire? Even \"last 30 minutes\" or \"around 2pm today\" drastically reduces cost.\n2. **Cluster name** \u2014 Which EKS cluster is alarming?"
+      },
+      "without_skill": {
+        "eval_id": 8,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on the 'look into' phrase",
+            "passed": false,
+            "evidence": "The output is a conversational response asking clarifying questions. There is no evidence that a skill was actually activated/invoked - no skill tool call is shown, just a text response.",
+            "method": "llm",
+            "confidence": 0.7,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions EKS or Kubernetes-related log groups or metrics",
+            "passed": true,
+            "evidence": "The output mentions 'EKS cluster', 'CloudWatch metrics', and 'nodes/pods' which are Kubernetes-related concepts, though it doesn't specifically list log groups.",
+            "method": "llm",
+            "confidence": 0.7,
+            "uncertain": false
+          },
+          {
+            "text": "The output lists CloudWatch GetMetricData as one of the resources to query",
+            "passed": false,
+            "evidence": "The output mentions 'check the CloudWatch metrics' generically but does not specifically list 'GetMetricData' as an API or resource to query.",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled",
+            "passed": false,
+            "evidence": "The investigation is not cancelled. The output is actively asking for more details to proceed with the investigation.",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks for a specific time window",
+            "passed": false,
+            "evidence": "The output asks for alarm name/ARN, cluster name/region, pipeline context, and AWS profile, but does not ask for a specific time window.",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.2,
+        "summary": "Without skill: 20% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 1,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 562,
+            "cache_read_input_tokens": 46227,
+            "cache_creation_input_tokens": 15663
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 21.70912216600027
+        },
+        "raw_output": "I'd like to help investigate the high CPU alarm on your production EKS cluster. I need a few details to look into this effectively:Could you share:\n\n1. **The alarm name or ARN** \u2014 or the EKS cluster name and AWS region so I can look it up.\n2. **Any pipeline context** \u2014 is this alarm blocking a deployment, or did you get paged directly?\n3. **AWS profile/credentials** \u2014 which AWS profile should I use (e.g., a ReadOnly profile for the production account)?\n\nWith those details I can check the CloudWatch metrics, identify which nodes/pods are driving the CPU spike, and help you determine root cause."
+      },
+      "delta_pass_rate": 0.8
+    },
+    {
+      "eval_id": 9,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 9,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on 'troubleshoot'",
+            "passed": true,
+            "evidence": "The output shows a troubleshooting investigation plan, implying a troubleshoot-related skill was activated, but the actual trigger/input is not visible in the output itself",
+            "method": "llm",
+            "confidence": 0.5,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions DynamoDB metrics or CloudTrail",
+            "passed": true,
+            "evidence": "Output explicitly mentions DynamoDB metrics (ThrottledRequests, ReadThrottleEvents, WriteThrottleEvents, Consumed/Provisioned capacity) and CloudTrail (CloudTrail LookupEvents in step 3)",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The time window is recognized as 15 minutes (9:00-9:15 UTC)",
+            "passed": true,
+            "evidence": "Output explicitly states '2026-06-21 09:00\u201309:15 UTC (15-minute window)' and references the 15-minute duration multiple times",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate based on the 15-minute window",
+            "passed": true,
+            "evidence": "Output provides cost estimates tied to the 15-minute window: $0.0009 for CloudWatch metrics (6 metrics \u00d7 15 periods), $0.00 for CloudTrail/DescribeTable, and notes 'With a 15-minute window, CloudWatch Metrics cost is negligible (<$0.01)'",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "A visual plan or step breakdown is presented",
+            "passed": true,
+            "evidence": "Output contains a formatted markdown table with 5 numbered steps, columns for Step, Data Source, Est. Volume, and Est. Cost, clearly presenting a visual step breakdown",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 1.0,
+        "summary": "With skill: 100% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 1793,
+            "cache_read_input_tokens": 15409,
+            "cache_creation_input_tokens": 19615
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 43.48140858299939
+        },
+        "raw_output": "I'll run the cost guardrail before investigating. I have a time window (09:00\u201309:15 UTC today, 15 minutes), but I need a few details to estimate costs accurately.\n\n## \ud83d\udccb Investigation Cost Estimate\n\n**Target:** DynamoDB throttling, 2026-06-21 09:00\u201309:15 UTC (15-minute window)\n\n### Planned Investigation Steps\n\n| # | Step | Data Source | Est. Volume | Est. Cost |\n|---|------|-------------|-------------|-----------|\n| 1 | Query DynamoDB throttling metrics (ThrottledRequests, ReadThrottleEvents, WriteThrottleEvents, Consumed/Provisioned capacity) | CloudWatch GetMetricData | ~6 metrics \u00d7 15 periods = 90 requests | $0.0009 |\n| 2 | Scan application logs for throttling errors | CloudWatch Logs Insights | \u26a0\ufe0f Unknown log group(s) | \u26a0\ufe0f Unknown |\n| 3 | Check for table capacity/scaling changes | CloudTrail LookupEvents | N/A | $0.00 (free) |\n| 4 | Check DynamoDB table settings (describe) | DynamoDB DescribeTable | N/A | $0.00 (free) |\n| 5 | Cross-region data transfer | \u2014 | \u26a0\ufe0f Unknown regions | \u26a0\ufe0f Unknown |\n\n**Running total:** \u26a0\ufe0f Cannot determine \u2014 missing inputs\n\n---\n\n### \u26a0\ufe0f Missing Information\n\nTo produce a reliable cost estimate and proceed, I need:\n\n1. **Which AWS region(s)** are the DynamoDB tables in? (needed for pricing rates and to detect cross-region transfer)\n2. **Which DynamoDB table(s)** are affected? (specific table names help scope the metric queries)\n3. **Are there application log groups** I should scan? (e.g., `/aws/lambda/...`, `/ecs/...`, a custom app log group) \u2014 this is the main cost driver\n\n### Why this matters\n\nWith a 15-minute window, CloudWatch Metrics cost is negligible (<$0.01). The main cost risk is **Logs Insights** \u2014 if your application log groups ingest heavily, even 15 minutes could be multiple GB. With the table/log group names and region, I can query `IncomingBytes` for that exact window and give you a precise estimate.\n\nCould you provide the region, table name(s), and any relevant log groups?"
+      },
+      "without_skill": {
+        "eval_id": 9,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on 'troubleshoot'",
+            "passed": true,
+            "evidence": "The output responds to a troubleshooting request about DynamoDB throttling, but there's no explicit evidence a 'skill' was activated (no skill invocation shown, just a conversational response)",
+            "method": "llm",
+            "confidence": 0.4,
+            "uncertain": true
+          },
+          {
+            "text": "The output mentions DynamoDB metrics or CloudTrail",
+            "passed": true,
+            "evidence": "Output explicitly mentions DynamoDB metrics: ConsumedReadCapacityUnits, ThrottledRequests, ReadThrottleEvents/WriteThrottleEvents, and CloudWatch metrics",
+            "method": "llm",
+            "confidence": 0.9,
+            "uncertain": false
+          },
+          {
+            "text": "The time window is recognized as 15 minutes (9:00-9:15 UTC)",
+            "passed": false,
+            "evidence": "No mention of any time window, 15 minutes, or 9:00-9:15 UTC anywhere in the output",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate based on the 15-minute window",
+            "passed": false,
+            "evidence": "No cost estimate is provided anywhere in the output; it only asks clarifying questions",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "A visual plan or step breakdown is presented",
+            "passed": false,
+            "evidence": "The output contains a numbered list of clarifying questions (1-3), not a visual plan or step breakdown for investigation. The final sentence hints at possible causes but doesn't constitute a structured plan",
+            "method": "llm",
+            "confidence": 0.75,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.4,
+        "summary": "Without skill: 40% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 346,
+            "cache_read_input_tokens": 15404,
+            "cache_creation_input_tokens": 15436
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 14.576237875000515
+        },
+        "raw_output": "I'd like to help troubleshoot the DynamoDB throttling, but I need a few details to investigate effectively:\n\n1. **Which table(s)** experienced throttling? (table name or service name)\n2. **Which AWS account and region** should I look at?\n3. **Do you have AWS credentials configured** I can use to query CloudWatch metrics (e.g., `ConsumedReadCapacityUnits`, `ThrottledRequests`, `ReadThrottleEvents`/`WriteThrottleEvents`)?\n\nIf you can point me to a specific service, package, or dashboard, I can dig into the metrics and application logs to identify whether this was caused by a hot partition, a capacity mismatch, a burst from a batch job, or something else."
+      },
+      "delta_pass_rate": 0.6
+    },
+    {
+      "eval_id": 10,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 10,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on the 'why is' phrase",
+            "passed": false,
+            "evidence": "The output shows no evidence of a skill activating. It's a conversational response asking clarifying questions, with no indication that a specific skill was triggered by a 'why is' phrase.",
+            "method": "llm",
+            "confidence": 0.6,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions Lambda log groups",
+            "passed": true,
+            "evidence": "Output explicitly mentions '/aws/lambda/<name>' as the log group format it would investigate.",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output interprets 'since yesterday' as a broad time window",
+            "passed": true,
+            "evidence": "Output says '\"Since yesterday\" gives me a start point' and refers to it as 'the full ~24h window', interpreting it as a broad time range.",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate",
+            "passed": false,
+            "evidence": "Output says it WILL 'produce a cost estimate' after getting details, but does not actually show a cost estimate in the current output.",
+            "method": "llm",
+            "confidence": 0.75,
+            "uncertain": false
+          },
+          {
+            "text": "The output suggests narrowing the time window to reduce cost",
+            "passed": true,
+            "evidence": "Output asks 'Can you narrow it further (e.g., started around 2pm UTC yesterday) or should I scan the full ~24h window?' \u2014 suggesting narrowing the time window, in the context of cost estimation discussion.",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.6,
+        "summary": "With skill: 60% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 798,
+            "cache_read_input_tokens": 15409,
+            "cache_creation_input_tokens": 19599
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 25.5329967079997
+        },
+        "raw_output": "I'd be happy to help investigate the Lambda timeout. Before I pull any data, I need a few details to estimate the investigation cost:\n\n1. **Which Lambda function?** \u2014 The function name or ARN (so I can identify the log group `/aws/lambda/<name>` and the region)\n2. **Which AWS region?** \u2014 Or I can derive it from the ARN if you have one\n3. **Time window** \u2014 \"Since yesterday\" gives me a start point. Can you narrow it further (e.g., \"started around 2pm UTC yesterday\") or should I scan the full ~24h window?\n\nWith those details I'll produce a cost estimate for the CloudWatch Logs Insights queries, metrics pulls, and any cross-region transfer before running anything."
+      },
+      "without_skill": {
+        "eval_id": 10,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on the 'why is' phrase",
+            "passed": false,
+            "evidence": "The output is a general response about Lambda timeouts with no indication that a specific 'skill' was activated or that it was triggered by a 'why is' phrase pattern",
+            "method": "llm",
+            "confidence": 0.6,
+            "uncertain": false
+          },
+          {
+            "text": "The output mentions Lambda log groups",
+            "passed": false,
+            "evidence": "The output mentions 'CloudWatch logs' twice but never specifically uses the term 'Lambda log groups'",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output interprets 'since yesterday' as a broad time window",
+            "passed": false,
+            "evidence": "The output asks about deployments/changes 'yesterday' but does not interpret 'since yesterday' as a broad time window or discuss time ranges for querying",
+            "method": "llm",
+            "confidence": 0.8,
+            "uncertain": false
+          },
+          {
+            "text": "The output shows a cost estimate",
+            "passed": false,
+            "evidence": "There is no cost estimate anywhere in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output suggests narrowing the time window to reduce cost",
+            "passed": false,
+            "evidence": "There is no mention of narrowing time windows to reduce cost in the output",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.0,
+        "summary": "Without skill: 0% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 514,
+            "cache_read_input_tokens": 15404,
+            "cache_creation_input_tokens": 15417
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 19.42709058300079
+        },
+        "raw_output": "A few common causes for sudden Lambda timeouts:\n\n1. **Downstream dependency** \u2014 a database, API, or service the function calls became slow or unreachable (most common cause of \"worked yesterday, doesn't today\")\n2. **VPC/networking** \u2014 if the function is in a VPC, a NAT gateway or security group change could block outbound traffic\n3. **Recent deployment** \u2014 a code or config change (new dependency, larger payload, connection pool exhaustion)\n4. **Resource limits** \u2014 concurrent execution throttling or an upstream rate limit causing retries\n\nTo help narrow it down:\n\n- What does the function do (what downstream services does it call)?\n- Is it in a VPC?\n- Were there any deployments or infra changes yesterday?\n- What do the CloudWatch logs show before the timeout \u2014 does execution get partway through, or does it hang immediately?\n\nThe fastest diagnostic is usually checking CloudWatch logs for the last successful invocation vs. the first failing one and comparing where execution stalls."
+      },
+      "delta_pass_rate": 0.6
+    },
+    {
+      "eval_id": 11,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 11,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions S3 or CloudTrail for access denied investigation",
+            "passed": true,
+            "evidence": "Output explicitly mentions both S3 access denied errors and CloudTrail LookupEvents as step 1 of the investigation plan",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "Cross-region is detected (ap-southeast-1 vs us-east-1)",
+            "passed": true,
+            "evidence": "Output explicitly states 'Agent Space region: us-east-1' and 'Workload region: ap-southeast-1 (cross-region)' and includes cross-region data transfer as step 5",
+            "method": "llm",
+            "confidence": 0.98,
+            "uncertain": false
+          },
+          {
+            "text": "Data transfer cost is included in the estimate",
+            "passed": true,
+            "evidence": "Step 5 explicitly includes 'Cross-region data transfer' with cost $0.0150, and it appears in the Cost Summary table as well",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The 10-minute time window is used for cost calculation",
+            "passed": true,
+            "evidence": "The output states 'Time window: 16:45 \u2013 16:55 UTC (10 minutes)' and references 'last 10 min' for CloudTrail and '10 periods' for metrics, and notes 'only a 10-minute window' when discussing fallback assumptions",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "A visual investigation plan is shown with per-step costs",
+            "passed": true,
+            "evidence": "A detailed table titled 'Visual Investigation Plan' is shown with columns for step number, step name, resource, data volume, and cost per step",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 1.0,
+        "summary": "With skill: 100% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 5,
+          "token_counts": {
+            "input_tokens": 6,
+            "output_tokens": 2426,
+            "cache_read_input_tokens": 121912,
+            "cache_creation_input_tokens": 22426
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 58.608747666000454
+        },
+        "raw_output": "I'll run the cost estimation before investigating. Let me query the relevant log groups and data volumes in ap-southeast-1.No AWS credentials available. I'll produce the cost estimation plan using fallback estimates.Now I have all the information I need. Here is the investigation cost estimation plan:\n\n---\n\n## \ud83d\udccb Investigation Cost Estimation Plan\n\n**Request:** Investigate S3 access denied errors in account `123456789012`, region `ap-southeast-1`  \n**Time window:** 16:45 \u2013 16:55 UTC (10 minutes)  \n**Agent Space region:** `us-east-1`  \n**Workload region:** `ap-southeast-1` (cross-region)\n\n---\n\n### Visual Investigation Plan\n\n| # | Step | Resource | Data Volume | Cost |\n|---|------|----------|-------------|------|\n| 1 | CloudTrail LookupEvents | `cloudtrail:LookupEvents` (S3 access denied events, last 10 min) | N/A | $0.00 \u2014 free |\n| 2 | CloudWatch Logs Insights | \u26a0\ufe0f S3 access logs (assumed log group, e.g., `/aws/s3/access-logs`) | \u26a0\ufe0f 5 GB (fallback \u2014 no permission to query) | $0.0250 |\n| 3 | CloudWatch GetMetricData | S3 `4xxErrors`, `AllRequests` metrics (~4 metrics \u00d7 10 periods) | 40 metric requests | $0.0004 |\n| 4 | Describe* API calls | S3 bucket policy, IAM policy checks | N/A | $0.00 \u2014 free |\n| 5 | Cross-region data transfer | Results returned from `ap-southeast-1` \u2192 `us-east-1` (Agent Space) | \u26a0\ufe0f ~0.75 GB (upper-bound: 5 GB \u00d7 0.15) | $0.0150 |\n\n---\n\n### Cost Summary\n\n| Component | Cost |\n|-----------|------|\n| CloudWatch Logs Insights | \u26a0\ufe0f $0.0250 |\n| CloudWatch GetMetricData | $0.0004 |\n| CloudTrail LookupEvents | $0.00 |\n| Describe* calls | $0.00 |\n| Cross-region data transfer | \u26a0\ufe0f $0.0150 |\n| **Total estimated** | **\u26a0\ufe0f $0.0404** |\n\n**Threshold:** $10.00\n\n---\n\n### \u2705 PROCEEDING \u2014 Estimated cost: $0.04 (within $10.00 threshold)\n\nThe estimated cost is well within the threshold, even with worst-case fallback assumptions (flagged \u26a0\ufe0f because AWS credentials were unavailable to query actual log group sizes \u2014 real cost is likely lower given only a 10-minute window).\n\n"
+      },
+      "without_skill": {
+        "eval_id": 11,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The output mentions S3 or CloudTrail for access denied investigation",
+            "passed": true,
+            "evidence": "Output explicitly mentions both S3 and CloudTrail multiple times in the context of investigating AccessDenied errors",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "Cross-region is detected (ap-southeast-1 vs us-east-1)",
+            "passed": true,
+            "evidence": "Output mentions 'Cross-region access from us-east-1 agent hitting ap-southeast-1 bucket' under common causes to check",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "Data transfer cost is included in the estimate",
+            "passed": false,
+            "evidence": "No data transfer cost or any cost estimate is mentioned anywhere in the output",
+            "method": "llm",
+            "confidence": 0.97,
+            "uncertain": false
+          },
+          {
+            "text": "The 10-minute time window is used for cost calculation",
+            "passed": false,
+            "evidence": "The output uses a 20-minute time window (16:35-16:55) for event querying, not a 10-minute window, and there is no cost calculation at all",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "A visual investigation plan is shown with per-step costs",
+            "passed": false,
+            "evidence": "While a numbered investigation plan is shown, there are no per-step costs or any cost figures included",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.4,
+        "summary": "Without skill: 40% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 1,
+          "token_counts": {
+            "input_tokens": 4,
+            "output_tokens": 915,
+            "cache_read_input_tokens": 46270,
+            "cache_creation_input_tokens": 15725
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 27.779919250000603
+        },
+        "raw_output": "I'll investigate the S3 access denied errors. Let me first check what AWS credentials and configuration are available in this environment.There are no AWS credentials configured in this environment. I cannot directly query CloudTrail, CloudWatch Logs, or S3 access logs to investigate the access denied errors.\n\nHowever, I can outline what you'd need to do and help if you can provide credentials or access. Here's the investigation approach:\n\n**To diagnose S3 AccessDenied errors (account 123456789012, ap-southeast-1, starting 16:45 UTC):**\n\n1. **CloudTrail** \u2014 Query for denied S3 events:\n   ```bash\n   aws cloudtrail lookup-events \\\n     --region ap-southeast-1 \\\n     --lookup-attributes AttributeKey=EventSource,AttributeValue=s3.amazonaws.com \\\n     --start-time \"2026-06-21T16:35:00Z\" \\\n     --end-time \"2026-06-21T16:55:00Z\" \\\n     --query 'Events[?contains(CloudTrailEvent, `AccessDenied`)]'\n   ```\n\n2. **CloudWatch Logs Insights** (if S3 server access logging or CloudTrail logs are in a log group):\n   ```\n   fields @timestamp, errorCode, requestParameters.bucketName, userIdentity.arn\n   | filter errorCode = \"AccessDenied\"\n   | sort @timestamp desc\n   | limit 50\n   ```\n\n3. **Common causes to check:**\n   - Bucket policy changes around 16:45 UTC\n   - IAM policy modifications (SCPs, identity policies)\n   - S3 Block Public Access settings changed\n   - VPC endpoint policy denying access\n   - KMS key policy (if objects are encrypted with CMK)\n   - Cross-region access from us-east-1 agent hitting ap-southeast-1 bucket with a VPC endpoint that's region-scoped\n\n**Would you like me to proceed with any of these if you can:**\n- Configure AWS credentials/profile for this account?\n- Provide CloudTrail event JSON or log snippets to analyze?\n- Share the bucket name(s) and IAM role/user ARN involved?"
+      },
+      "delta_pass_rate": 0.6
+    },
+    {
+      "eval_id": 12,
+      "run_index": 0,
+      "with_skill": {
+        "eval_id": 12,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on 'root cause'",
+            "passed": false,
+            "evidence": "The output shows an investigation-style response but does not explicitly confirm it was activated by the phrase 'root cause' - we cannot determine the trigger from the output alone",
+            "method": "llm",
+            "confidence": 0.5,
+            "uncertain": false
+          },
+          {
+            "text": "The output lists multiple log groups or services it would scan",
+            "passed": false,
+            "evidence": "The output does NOT list specific log groups or services it would scan; it asks the user to provide that information instead",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled (no time window, no specific service)",
+            "passed": false,
+            "evidence": "The investigation is not explicitly cancelled - it says it would 'likely exceed the $10 threshold and force a cancel' without a time window, but the actual state is paused/waiting for input, not cancelled",
+            "method": "llm",
+            "confidence": 0.6,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks which service was affected",
+            "passed": true,
+            "evidence": "Point 1 explicitly asks 'Which service/resource is affected? (e.g., service name, ARN, alarm name, or pipeline)'",
+            "method": "llm",
+            "confidence": 0.99,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks when the outage started",
+            "passed": true,
+            "evidence": "Point 3 asks 'What time window? (when did the outage start/end, or at minimum a timestamp near the incident)' which covers when the outage started",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.4,
+        "summary": "With skill: 40% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 388,
+            "cache_read_input_tokens": 15409,
+            "cache_creation_input_tokens": 19597
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 16.216400500000418
+        },
+        "raw_output": "I need more details before I can investigate. The investigation cost guardrail requires me to estimate AWS API costs before pulling any data.\n\nTo scope this properly, I need:\n\n1. **Which service/resource is affected?** (e.g., service name, ARN, alarm name, or pipeline)\n2. **Which AWS region(s)?** (where the workload runs)\n3. **What time window?** (when did the outage start/end, or at minimum a timestamp near the incident)\n4. **Which log groups are relevant?** (or I can infer from the service name)\n\nWithout at least a time window, I'll have to estimate worst-case scan costs against all stored log data, which will likely exceed the $10 threshold and force a cancel.\n\nWhat can you tell me about this outage?"
+      },
+      "without_skill": {
+        "eval_id": 12,
+        "run_index": 0,
+        "assertion_results": [
+          {
+            "text": "The skill activates on 'root cause'",
+            "passed": false,
+            "evidence": "The output responds to a root cause analysis request but shows no evidence of a skill being explicitly activated/invoked - it's just a conversational response asking for clarification",
+            "method": "llm",
+            "confidence": 0.6,
+            "uncertain": false
+          },
+          {
+            "text": "The output lists multiple log groups or services it would scan",
+            "passed": false,
+            "evidence": "The output does not list any log groups or services it would scan; it only asks clarifying questions",
+            "method": "llm",
+            "confidence": 0.95,
+            "uncertain": false
+          },
+          {
+            "text": "The investigation is cancelled (no time window, no specific service)",
+            "passed": true,
+            "evidence": "The investigation does not proceed - the assistant stops and asks for more context because no time window or specific service was provided",
+            "method": "llm",
+            "confidence": 0.85,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks which service was affected",
+            "passed": true,
+            "evidence": "Question 1 explicitly asks 'What service/system experienced the outage?'",
+            "method": "llm",
+            "confidence": 0.98,
+            "uncertain": false
+          },
+          {
+            "text": "The output asks when the outage started",
+            "passed": false,
+            "evidence": "The output mentions 'timeline' indirectly ('If you have logs, dashboards, or a timeline in mind') but does not explicitly ask when the outage started as a direct question",
+            "method": "llm",
+            "confidence": 0.6,
+            "uncertain": false
+          }
+        ],
+        "pass_rate": 0.4,
+        "summary": "Without skill: 40% assertions passed",
+        "execution_metrics": {
+          "tool_calls": 0,
+          "token_counts": {
+            "input_tokens": 3,
+            "output_tokens": 206,
+            "cache_read_input_tokens": 15404,
+            "cache_creation_input_tokens": 15416
+          }
+        },
+        "timing": {
+          "elapsed_seconds": 11.96572016600021
+        },
+        "raw_output": "I'd be happy to help with a root cause analysis, but I need more context. Could you share:\n\n1. **What service/system** experienced the outage?\n2. **What symptoms** were observed (errors, latency, availability drop)?\n3. **Any relevant links** \u2014 pipeline, alarms, tickets, or deployment IDs?\n\nIf you have logs, dashboards, or a timeline in mind, point me there and I can dig in. Otherwise, let me know the service name and I can look at recent pipeline/deployment health to get started."
+      },
+      "delta_pass_rate": 0.0
+    }
+  ],
+  "run_summary": {
+    "with_skill": {
+      "mean_pass_rate": 0.7264,
+      "stddev_pass_rate": 0.2638,
+      "mean_tokens": 1672.0,
+      "mean_input_tokens": 4.0,
+      "mean_output_tokens": 1672.0,
+      "mean_total_tokens": 1676.0,
+      "mean_tool_calls": 1.8
+    },
+    "without_skill": {
+      "mean_pass_rate": 0.2278,
+      "stddev_pass_rate": 0.215,
+      "mean_tokens": 644.4,
+      "mean_input_tokens": 8.9,
+      "mean_output_tokens": 644.4,
+      "mean_total_tokens": 653.3,
+      "mean_tool_calls": 1.5
+    },
+    "delta": {
+      "pass_rate": 0.4986,
+      "tokens": 1027.6,
+      "total_tokens": 1022.7,
+      "input_tokens": -4.9,
+      "tool_calls": 0.2
+    },
+    "cost_efficiency": {
+      "quality_delta": 0.4986,
+      "cost_delta_pct": 156.5,
+      "classification": "TRADEOFF",
+      "emoji": "\ud83d\udfe1",
+      "description": "Skill improves quality but increases cost"
+    },
+    "estimated_cost": {
+      "with_skill_per_run": {
+        "input_cost": 1.2e-05,
+        "output_cost": 0.02508,
+        "total_cost": 0.025092,
+        "model": "sonnet",
+        "currency": "USD"
+      },
+      "without_skill_per_run": {
+        "input_cost": 2.7e-05,
+        "output_cost": 0.009666,
+        "total_cost": 0.009693,
+        "model": "sonnet",
+        "currency": "USD"
+      },
+      "per_eval_pair": 0.034785,
+      "total_runs": 12,
+      "total_cost": 0.4174,
+      "model": "sonnet",
+      "currency": "USD"
+    }
+  },
+  "scores": {
+    "outcome": 0.7264,
+    "process": 1.0,
+    "style": 0.7264,
+    "efficiency": 1.0,
+    "overall": 0.8632
+  },
+  "passed": true
+}

--- a/skills/investigation-cost-guardrail/evals/eval_queries.json
+++ b/skills/investigation-cost-guardrail/evals/eval_queries.json
@@ -1,25 +1,5 @@
 [
   {
-    "query": "What's the weather like today?",
-    "should_trigger": false,
-    "reason": "Completely unrelated to investigation, debugging, or troubleshooting"
-  },
-  {
-    "query": "Create a new S3 bucket called my-data-bucket",
-    "should_trigger": false,
-    "reason": "Resource creation task, not an investigation"
-  },
-  {
-    "query": "Deploy my CDK stack to production",
-    "should_trigger": false,
-    "reason": "Deployment task, not troubleshooting"
-  },
-  {
-    "query": "Generate a Well-Architected review for my workload",
-    "should_trigger": false,
-    "reason": "Assessment/review task, not incident investigation"
-  },
-  {
     "query": "How much does an m5.xlarge cost per hour?",
     "should_trigger": false,
     "reason": "Pricing question, not incident investigation"

--- a/skills/investigation-cost-guardrail/evals/eval_queries.json
+++ b/skills/investigation-cost-guardrail/evals/eval_queries.json
@@ -1,0 +1,52 @@
+[
+  {
+    "query": "What's the weather like today?",
+    "should_trigger": false,
+    "reason": "Completely unrelated to investigation, debugging, or troubleshooting"
+  },
+  {
+    "query": "Create a new S3 bucket called my-data-bucket",
+    "should_trigger": false,
+    "reason": "Resource creation task, not an investigation"
+  },
+  {
+    "query": "Deploy my CDK stack to production",
+    "should_trigger": false,
+    "reason": "Deployment task, not troubleshooting"
+  },
+  {
+    "query": "Generate a Well-Architected review for my workload",
+    "should_trigger": false,
+    "reason": "Assessment/review task, not incident investigation"
+  },
+  {
+    "query": "How much does an m5.xlarge cost per hour?",
+    "should_trigger": false,
+    "reason": "Pricing question, not incident investigation"
+  },
+  {
+    "query": "What EC2 instances are running in us-east-1?",
+    "should_trigger": false,
+    "reason": "Inventory query, not troubleshooting or debugging"
+  },
+  {
+    "query": "Scale my ECS service to 10 tasks",
+    "should_trigger": false,
+    "reason": "Scaling action, not investigating a problem"
+  },
+  {
+    "query": "How do I enable GuardDuty in my account?",
+    "should_trigger": false,
+    "reason": "Setup/enablement question, not incident response"
+  },
+  {
+    "query": "Generate a cost report for last month broken down by service",
+    "should_trigger": false,
+    "reason": "Reporting task, not debugging or incident response"
+  },
+  {
+    "query": "What are the best practices for tagging AWS resources?",
+    "should_trigger": false,
+    "reason": "Best practices question, not troubleshooting"
+  }
+]

--- a/skills/investigation-cost-guardrail/evals/evals.json
+++ b/skills/investigation-cost-guardrail/evals/evals.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": 1,
+    "prompt": "Investigate",
+    "expected_output": "The skill activates with no context, lists all discoverable log groups and their stored sizes, shows a worst-case cost estimate, cancels the investigation, and tells the user what information to provide (exact time, service name, error message) to reduce cost.",
+    "assertions": [
+      "The output mentions CloudWatch Logs or log groups",
+      "The output shows a dollar cost estimate with at least 4 decimal places",
+      "The investigation is cancelled (mentions 'cancel' or 'cancelled')",
+      "The output asks the user to provide a time window or timestamp",
+      "The output lists what information is missing to make it cheaper"
+    ]
+  },
+  {
+    "id": 2,
+    "prompt": "Investigate why the ECS service is failing",
+    "expected_output": "The skill identifies ECS-related log groups, shows worst-case cost (no time window provided), cancels the investigation, and asks the user to provide the exact time the failure started.",
+    "assertions": [
+      "The output mentions ECS or container-related log groups",
+      "The output shows a cost estimate in dollars",
+      "The investigation is cancelled because no time window was provided",
+      "The output asks for an exact incident time or time window",
+      "The output suggests that providing a time window would reduce cost by 90% or more"
+    ]
+  },
+  {
+    "id": 3,
+    "prompt": "Investigate Lambda errors in the last 24 hours",
+    "expected_output": "The skill identifies Lambda log groups, queries IncomingBytes for a 24-hour window, calculates the scan cost, shows it exceeds the threshold, cancels, and suggests narrowing to last 1 hour or last 15 minutes.",
+    "assertions": [
+      "The output mentions Lambda log groups",
+      "The output shows a cost calculation based on data volume (GB) multiplied by $0.005",
+      "The estimated cost exceeds the threshold",
+      "The investigation is cancelled due to cost exceeding threshold",
+      "The output suggests narrowing the time window (e.g., last 1 hour or last 15 minutes)"
+    ]
+  },
+  {
+    "id": 4,
+    "prompt": "Investigate the ECS crash that happened at 14:15 UTC today, look at the last 5 minutes only",
+    "expected_output": "The skill identifies ECS log groups, queries IncomingBytes for a 5-minute window, shows a very low cost estimate, presents a visual investigation plan with steps and per-step costs.",
+    "assertions": [
+      "The output uses IncomingBytes or mentions querying actual data volume for the time window",
+      "The output shows a cost estimate that is very small (sub-cent)",
+      "The output includes a visual plan or step-by-step breakdown of what the agent will do",
+      "Each step in the plan shows its estimated cost"
+    ]
+  },
+  {
+    "id": 5,
+    "prompt": "Investigate the RDS issue in eu-west-1. My agent space is in us-east-1.",
+    "expected_output": "The skill detects a cross-region mismatch between agent space (us-east-1) and workload (eu-west-1), includes data transfer cost ($0.02/GB) in the estimate, and shows both regions in the investigation plan.",
+    "assertions": [
+      "The output mentions cross-region or data transfer",
+      "The output includes a data transfer cost component ($0.02/GB or similar)",
+      "The output mentions both us-east-1 and eu-west-1",
+      "The investigation is cancelled (no time window provided)"
+    ]
+  },
+  {
+    "id": 6,
+    "prompt": "Debug the NullPointerException error in Lambda function data-processor from the last 10 minutes",
+    "expected_output": "The skill recognizes a known error message is provided and suggests using FilterLogEvents (free) instead of Logs Insights as a cheaper alternative.",
+    "assertions": [
+      "The output mentions the Lambda function or /aws/lambda/ log group",
+      "The output mentions FilterLogEvents as a free alternative to Logs Insights",
+      "The output acknowledges that providing the exact error message enables cheaper investigation"
+    ]
+  },
+  {
+    "id": 7,
+    "prompt": "What happened to my API Gateway? It's returning 502 errors",
+    "expected_output": "The skill activates on 'what happened' trigger, identifies API Gateway log groups, shows worst-case cost without a time window, cancels, and asks for the exact time the 502 errors started.",
+    "assertions": [
+      "The skill activates (does not ignore the prompt)",
+      "The output mentions API Gateway or related log groups",
+      "The investigation is cancelled due to missing time window",
+      "The output asks when the 502 errors started"
+    ]
+  },
+  {
+    "id": 8,
+    "prompt": "Look into the high CPU alarm on our production EKS cluster",
+    "expected_output": "The skill activates on 'look into' trigger, identifies EKS/Container Insights log groups and CloudWatch metrics, shows the resources it would query, cancels without a time window, and asks for specifics.",
+    "assertions": [
+      "The skill activates on the 'look into' phrase",
+      "The output mentions EKS or Kubernetes-related log groups or metrics",
+      "The output lists CloudWatch GetMetricData as one of the resources to query",
+      "The investigation is cancelled",
+      "The output asks for a specific time window"
+    ]
+  },
+  {
+    "id": 9,
+    "prompt": "Troubleshoot the DynamoDB throttling issues we saw this morning between 9:00 and 9:15 UTC",
+    "expected_output": "The skill activates on 'troubleshoot' trigger, identifies DynamoDB-related metrics and possibly CloudTrail, queries IncomingBytes for the 15-minute window, and presents a cost estimate with visual plan.",
+    "assertions": [
+      "The skill activates on 'troubleshoot'",
+      "The output mentions DynamoDB metrics or CloudTrail",
+      "The time window is recognized as 15 minutes (9:00-9:15 UTC)",
+      "The output shows a cost estimate based on the 15-minute window",
+      "A visual plan or step breakdown is presented"
+    ]
+  },
+  {
+    "id": 10,
+    "prompt": "Why is my Lambda function timing out since yesterday?",
+    "expected_output": "The skill activates on 'why is' trigger, identifies Lambda log groups, but 'since yesterday' is a very broad window (24+ hours). The skill shows the estimated cost for scanning that volume and likely cancels, suggesting to narrow to a specific hour.",
+    "assertions": [
+      "The skill activates on the 'why is' phrase",
+      "The output mentions Lambda log groups",
+      "The output interprets 'since yesterday' as a broad time window",
+      "The output shows a cost estimate",
+      "The output suggests narrowing the time window to reduce cost"
+    ]
+  },
+  {
+    "id": 11,
+    "prompt": "Investigate the S3 access denied errors in account 123456789012, region ap-southeast-1. Agent space is in us-east-1. Errors started at 16:45 UTC, check last 10 minutes.",
+    "expected_output": "The skill identifies S3 access patterns (CloudTrail data events), detects cross-region (ap-southeast-1 vs us-east-1), uses the 10-minute window, calculates scan cost + data transfer cost, and presents a full visual plan.",
+    "assertions": [
+      "The output mentions S3 or CloudTrail for access denied investigation",
+      "Cross-region is detected (ap-southeast-1 vs us-east-1)",
+      "Data transfer cost is included in the estimate",
+      "The 10-minute time window is used for cost calculation",
+      "A visual investigation plan is shown with per-step costs"
+    ]
+  },
+  {
+    "id": 12,
+    "prompt": "Root cause analysis on the production outage",
+    "expected_output": "The skill activates on 'root cause' trigger, but with no service specified and no time window, it lists all discoverable resources, shows worst-case cost, cancels, and asks what service was affected and when the outage started.",
+    "assertions": [
+      "The skill activates on 'root cause'",
+      "The output lists multiple log groups or services it would scan",
+      "The investigation is cancelled (no time window, no specific service)",
+      "The output asks which service was affected",
+      "The output asks when the outage started"
+    ]
+  }
+]

--- a/skills/investigation-cost-guardrail/evals/report.json
+++ b/skills/investigation-cost-guardrail/evals/report.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "investigation-cost-guardrail",
+  "skill_path": "Devops-Agent-Finops-Skills-main",
+  "timestamp": "2026-06-21T01:23:33Z",
+  "overall_score": 0.9133,
+  "overall_grade": "A",
+  "passed": true,
+  "sections": {
+    "audit": {
+      "score": 92,
+      "grade": "A",
+      "passed": true,
+      "normalized": 0.92,
+      "critical": 0,
+      "warning": 0,
+      "info": 4
+    },
+    "functional": {
+      "overall": 0.8632,
+      "grade": "B",
+      "passed": true,
+      "scores": {
+        "outcome": 0.7264,
+        "process": 1.0,
+        "style": 0.7264,
+        "efficiency": 1.0,
+        "overall": 0.8632
+      },
+      "cost_efficiency": {
+        "quality_delta": 0.4986,
+        "cost_delta_pct": 156.5,
+        "classification": "TRADEOFF",
+        "emoji": "\ud83d\udfe1",
+        "description": "Skill improves quality but increases cost"
+      },
+      "estimated_cost": {
+        "with_skill_per_run": {
+          "input_cost": 1.2e-05,
+          "output_cost": 0.02508,
+          "total_cost": 0.025092,
+          "model": "sonnet",
+          "currency": "USD"
+        },
+        "without_skill_per_run": {
+          "input_cost": 2.7e-05,
+          "output_cost": 0.009666,
+          "total_cost": 0.009693,
+          "model": "sonnet",
+          "currency": "USD"
+        },
+        "per_eval_pair": 0.034785,
+        "total_runs": 12,
+        "total_cost": 0.4174,
+        "model": "sonnet",
+        "currency": "USD"
+      }
+    },
+    "trigger": {
+      "pass_rate": 1.0,
+      "grade": "A",
+      "passed": true,
+      "total_queries": 6
+    }
+  }
+}

--- a/skills/investigation-cost-guardrail/evals/trigger_report.json
+++ b/skills/investigation-cost-guardrail/evals/trigger_report.json
@@ -1,0 +1,94 @@
+{
+  "skill_name": "investigation-cost-guardrail",
+  "skill_path": "Devops-Agent-Finops-Skills-main",
+  "query_results": [
+    {
+      "query": "How much does an m5.xlarge cost per hour?",
+      "should_trigger": false,
+      "trigger_count": 0,
+      "run_count": 1,
+      "trigger_rate": 0.0,
+      "passed": true,
+      "mean_input_tokens": 3.0,
+      "mean_output_tokens": 262.0,
+      "mean_total_tokens": 265.0
+    },
+    {
+      "query": "What EC2 instances are running in us-east-1?",
+      "should_trigger": false,
+      "trigger_count": 0,
+      "run_count": 1,
+      "trigger_rate": 0.0,
+      "passed": true,
+      "mean_input_tokens": 4.0,
+      "mean_output_tokens": 403.0,
+      "mean_total_tokens": 407.0
+    },
+    {
+      "query": "Scale my ECS service to 10 tasks",
+      "should_trigger": false,
+      "trigger_count": 0,
+      "run_count": 1,
+      "trigger_rate": 0.0,
+      "passed": true,
+      "mean_input_tokens": 3.0,
+      "mean_output_tokens": 230.0,
+      "mean_total_tokens": 233.0
+    },
+    {
+      "query": "How do I enable GuardDuty in my account?",
+      "should_trigger": false,
+      "trigger_count": 0,
+      "run_count": 1,
+      "trigger_rate": 0.0,
+      "passed": true,
+      "mean_input_tokens": 3.0,
+      "mean_output_tokens": 452.0,
+      "mean_total_tokens": 455.0
+    },
+    {
+      "query": "Generate a cost report for last month broken down by service",
+      "should_trigger": false,
+      "trigger_count": 0,
+      "run_count": 1,
+      "trigger_rate": 0.0,
+      "passed": true,
+      "mean_input_tokens": 6.0,
+      "mean_output_tokens": 608.0,
+      "mean_total_tokens": 614.0
+    },
+    {
+      "query": "What are the best practices for tagging AWS resources?",
+      "should_trigger": false,
+      "trigger_count": 0,
+      "run_count": 1,
+      "trigger_rate": 0.0,
+      "passed": true,
+      "mean_input_tokens": 3.0,
+      "mean_output_tokens": 561.0,
+      "mean_total_tokens": 564.0
+    }
+  ],
+  "summary": {
+    "total_queries": 6,
+    "passed": 6,
+    "failed": 0,
+    "trigger_precision": 1.0,
+    "no_trigger_precision": 1.0,
+    "mean_total_tokens_per_run": 423.0,
+    "estimated_cost": {
+      "per_run": {
+        "input_cost": 1.1e-05,
+        "output_cost": 0.00629,
+        "total_cost": 0.006301,
+        "model": "sonnet",
+        "currency": "USD"
+      },
+      "total_runs": 6,
+      "total_cost": 0.0378,
+      "model": "sonnet",
+      "currency": "USD"
+    }
+  },
+  "passed": true
+}

--- a/skills/investigation-cost-guardrail/references/example-output.md
+++ b/skills/investigation-cost-guardrail/references/example-output.md
@@ -1,0 +1,146 @@
+# Example Output
+
+The default threshold is **$10.00**: investigations proceed automatically when the estimate is under it, and cancel (requesting approval) when it is exceeded. A missing time window always cancels regardless of cost. Setting the threshold to `$0` is the most conservative mode (always cancel and show cost before any paid query).
+
+## Contents
+- PROCEED — estimate within threshold
+- CANCEL — estimate exceeds threshold
+- CANCEL — no time window provided
+- Conservative mode ($0 threshold)
+- Partial capability (APIs blocked)
+
+## PROCEED — estimate within threshold
+
+```
+📋 INVESTIGATION COST ESTIMATE
+═══════════════════════════════════════════════════════════
+Target:        ECS task crashes on payments-api
+Time Window:   2026-06-20 14:00–14:30 UTC (30 min)
+Region:        us-east-1 (same as Agent Space, no transfer)
+Threshold:     $10.00 (default)
+
+Step                                      Data        Cost
+Logs Insights  /aws/ecs/payments-api      6.4 GB      $0.0320
+Logs Insights  /aws/ecs/payments-worker   2.1 GB      $0.0105
+GetMetricData  6 metrics × 30 periods     180 req     $0.0018
+X-Ray traces   ~18,000                    18,000      $0.0090
+───────────────────────────────────────────────────────────
+TOTAL ESTIMATED COST: $0.0533
+
+✅ PROCEEDING — $0.05 is within the $10.00 threshold.
+```
+
+## CANCEL — estimate exceeds threshold
+
+```
+📋 INVESTIGATION COST ESTIMATE
+═══════════════════════════════════════════════════════════
+Target:        Intermittent platform latency, last 7 days
+Time Window:   2026-06-13 → 2026-06-20 (7 days)
+Region:        eu-west-1 workload, us-east-1 Agent Space
+Threshold:     $10.00 (default)
+
+Step                                      Data        Cost
+Logs Insights  5 log groups, 7-day window 2,850 GB    $14.2500
+GetMetricData  40 metrics × 2,016 periods 80,640 req  $0.8064
+X-Ray traces   ~3,200,000                 3.2M        $1.6000
+Cross-region   results us-east-1←eu-west-1 ~85 GB     $1.7100
+───────────────────────────────────────────────────────────
+TOTAL ESTIMATED COST: $18.37
+
+🚫 CANCELLED — estimated cost ($18.37) exceeds the $10.00 threshold.
+
+💡 Suggestions to reduce cost:
+  → Narrow to a 1-hour window around the spike → ~$0.12
+  → Target the specific service instead of all 5 log groups
+  → Provide the exact error/latency signature → use FilterLogEvents (free)
+  → "Same region only" → removes the $1.71 cross-region transfer
+
+Approve to proceed at $18.37, or provide a narrower scope.
+```
+
+## CANCEL — no time window provided
+
+```
+📋 INVESTIGATION COST ESTIMATE
+═══════════════════════════════════════════════════════════
+Target:        "Investigate why the API is slow" (no time window)
+Region:        us-east-1
+Threshold:     $10.00 (default)
+
+Step                                      Data (stored)   Cost (worst case)
+Logs Insights  /aws/ecs/prod-api          45.2 GB         $0.2260
+Logs Insights  /aws/ecs/prod-worker       89.7 GB         $0.4485
+GetMetricData  4 metrics × 60 periods     240 req         $0.0024
+───────────────────────────────────────────────────────────
+TOTAL WORST-CASE COST: $0.6769
+
+🚫 CANCELLED — no time window provided (worst-case scan: 134.9 GB).
+A missing time window always cancels, regardless of cost.
+
+❓ What's missing to make this cheaper:
+  → Exact time the incident happened (e.g., "14:15 UTC today") → reduces scan 90%+
+  → Which service is affected (e.g., "ECS prod-api") → narrows to one log group
+  → The error message you saw → enables free FilterLogEvents instead of Logs Insights
+```
+
+## Conservative mode ($0 threshold)
+
+With the threshold set to `$0`, the guardrail always shows the cost and cancels pending approval before running any paid query, even when the estimate is tiny:
+
+```
+📋 INVESTIGATION COST ESTIMATE
+═══════════════════════════════════════════════════════════
+Target:        ECS crash on prod-api, 14:10–14:15 UTC
+Region:        us-east-1
+Threshold:     $0.00 (conservative mode)
+
+Step                                      Data        Cost
+Logs Insights  /aws/ecs/prod-api          0.041 GB    $0.000205
+GetMetricData  4 metrics × 5 periods      20 req      $0.000200
+───────────────────────────────────────────────────────────
+TOTAL ESTIMATED COST: $0.000405
+
+🚫 CANCELLED — threshold is $0.00; awaiting operator approval.
+Raise the threshold (e.g., $10.00) to let low-cost investigations proceed automatically.
+```
+
+## Partial capability (APIs blocked)
+
+```
+📋 INVESTIGATION COST ESTIMATE
+═══════════════════════════════════════════════════════════
+Target:        Lambda "order-processor" errors
+Time Window:   2026-06-20 14:00 → 15:00 UTC (1 hour)
+Region:        us-east-1 (same as Agent Space, no transfer)
+Threshold:     $10.00 (default)
+
+┌────────────────────────────────┬──────────┬─────────────┐
+│ STEP                           │ DATA     │ COST        │
+├────────────────────────────────┼──────────┼─────────────┤
+│ CloudWatch Logs Insights       │ 0.52 GB  │ $0.0026     │
+│   /aws/lambda/order-processor  │          │             │
+├────────────────────────────────┼──────────┼─────────────┤
+│ CloudWatch GetMetricData       │ 120 req  │ $0.0012     │
+│   4 metrics × 30 periods       │          │             │
+├────────────────────────────────┼──────────┼─────────────┤
+│ X-Ray Trace Scan               │ ~5,000   │ $0.0025     │
+│   (extrapolated from sample)   │          │             │
+├────────────────────────────────┼──────────┼─────────────┤
+│ CloudTrail LookupEvents        │ N/A      │ $0.00       │
+│   BLOCKED BY PLATFORM          │          │ (free API)  │
+├────────────────────────────────┼──────────┼─────────────┤
+│ Pricing API                    │ N/A      │ N/A         │
+│   BLOCKED — using fallback rate│          │             │
+└────────────────────────────────┴──────────┴─────────────┘
+
+TOTAL ESTIMATED COST:  $0.0063
+THRESHOLD:             $10.00
+DATA TRANSFER:         $0.00 (same region)
+
+⚠️ Limitations:
+• Pricing rates are fallback estimates; actual regional rates may differ
+• CloudTrail access blocked; investigation cannot analyze infrastructure changes
+
+✅ PROCEEDING — cost ($0.0063) is within the $10.00 threshold.
+```

--- a/skills/investigation-cost-guardrail/references/pricing-reference.md
+++ b/skills/investigation-cost-guardrail/references/pricing-reference.md
@@ -1,0 +1,124 @@
+# AWS Pricing Reference for Investigation Cost Estimation
+
+## Pricing API usage
+
+You MUST query the AWS Pricing API at runtime to get accurate per-unit rates for the workload region. The Pricing API is free and runs only in us-east-1 or ap-south-1.
+
+If the Pricing API fails (permissions, timeout), fall back to the floor estimates listed below and flag with ⚠️ in the visual plan.
+
+## CloudWatch Logs Insights
+
+```bash
+aws pricing get-products \
+  --service-code AmazonCloudWatch \
+  --filters "Type=TERM_MATCH,Field=regionCode,Value=<WORKLOAD_REGION>" \
+            "Type=TERM_MATCH,Field=usagetype,Value=<REGION_PREFIX>-DataScanned-Bytes" \
+  --region us-east-1
+```
+
+- **Fallback floor**: $0.005/GB
+- **Formula**: `scan_gb × regional_rate`
+
+## CloudWatch GetMetricData
+
+```bash
+aws pricing get-products \
+  --service-code AmazonCloudWatch \
+  --filters "Type=TERM_MATCH,Field=regionCode,Value=<WORKLOAD_REGION>" \
+            "Type=TERM_MATCH,Field=usagetype,Value=<REGION_PREFIX>-MetricMonitoring" \
+  --region us-east-1
+```
+
+- **Fallback floor**: $0.01/1,000 metrics requested
+- **Formula**: `(num_metrics × num_periods) / 1000 × regional_rate`
+
+## X-Ray
+
+```bash
+aws pricing get-products \
+  --service-code AWSXRay \
+  --filters "Type=TERM_MATCH,Field=regionCode,Value=<WORKLOAD_REGION>" \
+            "Type=TERM_MATCH,Field=usagetype,Value=<REGION_PREFIX>-TracesScanned" \
+  --region us-east-1
+```
+
+- **Fallback floor**: $0.50/1,000,000 traces
+- **Formula**: `estimated_traces / 1,000,000 × regional_rate`
+
+## CloudWatch Contributor Insights
+
+```bash
+aws pricing get-products \
+  --service-code AmazonCloudWatch \
+  --filters "Type=TERM_MATCH,Field=regionCode,Value=<WORKLOAD_REGION>" \
+            "Type=TERM_MATCH,Field=usagetype,Value=<REGION_PREFIX>-ContributorInsights-MatchingEvents" \
+  --region us-east-1
+```
+
+- **Fallback floor**: $0.02/rule/1,000 matching events
+- **Formula**: `num_rules × (matching_events / 1000) × regional_rate`
+
+## CloudWatch Live Tail
+
+```bash
+aws pricing get-products \
+  --service-code AmazonCloudWatch \
+  --filters "Type=TERM_MATCH,Field=regionCode,Value=<WORKLOAD_REGION>" \
+            "Type=TERM_MATCH,Field=usagetype,Value=<REGION_PREFIX>-LiveTail-SessionTime" \
+  --region us-east-1
+```
+
+- **Fallback floor**: $0.01/minute/session
+- **Formula**: `session_minutes × regional_rate`
+
+## Cross-Region Data Transfer
+
+- **Price**: $0.02/GB (inter-region, consistent across region pairs)
+- **What's billed**: only the **result bytes returned** across regions, NOT the scanned volume
+- **Estimation**: depends on query type — aggregations/stats return ~nothing (~1% of scan, or a few MB); raw event/trace fetches can return up to ~100% of matched bytes. When the query shape is unknown, use `scan_gb × 0.15` as a rough UPPER-BOUND and flag with ⚠️
+- **Formula**: `returned_data_gb × $0.02` (use actual returned size when known; 0.15 factor is a fallback only)
+
+No Pricing API call needed — data transfer pricing is consistent.
+
+## Free APIs (no cost, no lookup needed)
+
+- `logs:DescribeLogGroups` — free
+- `logs:FilterLogEvents` — free
+- `cloudtrail:LookupEvents` — free
+- `EC2/ECS/RDS Describe*` calls — free
+- `cloudwatch:GetMetricStatistics` — negligible ($0.01 per 1,000 requests)
+
+## Region prefix mapping
+
+The `<REGION_PREFIX>` in usagetype filters follows this pattern:
+
+> **us-east-1 caveat:** most us-east-1 usage types carry **no prefix** (e.g., `DataScanned-Bytes`), but some — often newer ones — use a **`USE1-`** prefix (e.g., `USE1-DataScanned-Bytes`). AWS is inconsistent here. For us-east-1, query the **unprefixed** usage type first; if the Pricing API returns no results, **retry with the `USE1-` prefix** before falling back to the floor rate. This avoids a silent floor-fallback when only the prefixed form exists.
+
+| Region | Prefix |
+|---|---|
+| us-east-1 | (usually none; try `USE1-` if no match) |
+| us-east-2 | USE2 |
+| us-west-1 | USW1 |
+| us-west-2 | USW2 |
+| eu-west-1 | EU |
+| eu-west-2 | EUW2 |
+| eu-west-3 | EUW3 |
+| eu-central-1 | EUC1 |
+| eu-north-1 | EUN1 |
+| ap-southeast-1 | APS1 |
+| ap-southeast-2 | APS2 |
+| ap-northeast-1 | APN1 |
+| ap-northeast-2 | APN2 |
+| ap-south-1 | APS3 |
+| sa-east-1 | SAE1 |
+| ca-central-1 | CAN1 |
+| me-south-1 | MES1 |
+| af-south-1 | AFS1 |
+
+## Documentation
+
+- [CloudWatch Pricing](https://aws.amazon.com/cloudwatch/pricing/)
+- [CloudTrail Pricing](https://aws.amazon.com/cloudtrail/pricing/)
+- [X-Ray Pricing](https://aws.amazon.com/xray/pricing/)
+- [AWS Data Transfer Pricing](https://aws.amazon.com/ec2/pricing/on-demand/#Data_Transfer)
+- [AWS Pricing API](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/price-changes.html)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add devops agent investigation cost guardrail skill to estimate downstream AWS API cost before an incident investigation runs, shows a per-step cost plan, and proceeds/cancels against a threshold (default $10)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
