### PR TITLE
Update docs, README, and other files, following repo rename

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ This repository consolidates AWS DevOps Agent skills. Follow these conventions w
 ## Repository Structure
 
 ```
-sample-code-for-devops-agent-skills/
+sample-devops-agent-tools/
 ├── README.md                 # Project overview with skills table
 ├── .gitignore                # Root-level ignores
 ├── skills/

--- a/.kiro/steering/project-conventions.md
+++ b/.kiro/steering/project-conventions.md
@@ -11,7 +11,7 @@ This repository consolidates AWS DevOps Agent skills. Follow these conventions w
 ## Repository Structure
 
 ```
-sample-code-for-devops-agent-skills/
+sample-devops-agent-tools/
 ├── README.md                 # Project overview with skills table
 ├── .gitignore                # Root-level ignores
 ├── skills/

--- a/README.md
+++ b/README.md
@@ -1,98 +1,39 @@
-# AWS DevOps Agent Skills
+# AWS DevOps Agent Tools
 
 ![License: MIT-0](https://img.shields.io/badge/License-MIT--0-blue)
 ![AWS DevOps Agent](https://img.shields.io/badge/AWS-DevOps%20Agent-orange?logo=amazonaws)
 
-Open-source skills for [AWS DevOps Agent](https://aws.amazon.com/devops-agent/) that extend its capabilities for incident response, root cause analysis, and operational troubleshooting.
+Open-source skills, custom agents, and infrastructure templates for [AWS DevOps Agent](https://aws.amazon.com/devops-agent/) that extend its capabilities for incident response, root cause analysis, and operational troubleshooting.
 
 ## ⚠️ Important Notice
 
-These skills are provided as sample code. If you intend to deploy these skills in production, start with a non-production environment first. Before deploying any skill to a production environment:
+These tools are provided as sample code. If you intend to deploy them in production, start with a non-production environment first, and before deploying to production:
 
 - Test thoroughly in a non-production environment first
 - Review IAM permissions and security configurations against your organization's policies
-- Validate that skill behavior meets your operational requirements
+- Validate that behavior meets your operational requirements
 
 See the [LICENSE](LICENSE) file for terms of use.
 
 ---
 
-Each skill provides domain-specific knowledge, decision trees, and step-by-step runbooks that the agent follows during investigations. Use them as-is to enhance AWS DevOps agent, or as templates for writing your own custom skills.
+This repository contains:
 
-All skills were tested using [Agent Skill Eval](https://github.com/aws-samples/sample-agent-skill-eval) and manually in DevOps Agent web app, for functionality without skill and with skill, and for effective triggering. The tests reports are available in each skill's `evals/` directory.
+- **Skills** — Domain-specific knowledge, decision trees, and step-by-step runbooks that the agent follows during investigations. Use them as-is or as templates for writing your own. Browse the [Skills Catalog](https://aws-samples.github.io/sample-devops-agent-tools/skills/).
+- **Custom Agents** — Pre-built agent configurations with system prompts and tool assignments for recurring operational workflows like health reports and operational reviews. Browse the [Custom Agents Catalog](https://aws-samples.github.io/sample-devops-agent-tools/custom-agents/).
+- **CloudFormation Templates** — Infrastructure-as-code for provisioning IAM permissions that skills require.
 
-## What Are AWS DevOps Agent Skills?
+All tools are contributed and tested according to the [contribution guidelines](CONTRIBUTING.md).
 
-AWS DevOps Agent skills are structured instruction sets that teach the agent how to investigate specific operational scenarios. Skills follow the open [Agent Skills specification](https://agentskills.io/home) and can be uploaded to your DevOps Agent deployment to extend its knowledge beyond built-in capabilities.
+## What Are Skills and Custom Agents?
 
-Skills enable DevOps Agent to:
+**Skills** are structured instruction sets that teach the agent how to investigate specific operational scenarios. They follow the open [Agent Skills specification](https://agentskills.io/home) and can be uploaded to your Agent Space to extend the agent's knowledge beyond built-in capabilities. See the [DevOps Agent skills documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html) for more information.
 
-- Specialize with investigation procedures, best practices, and organizational knowledge specific to your infrastructure
-- Automatically load relevant instructions during investigations, eliminating repetitive guidance
-- Compose multiple skills for end-to-end investigation workflows (e.g., retrieving deployments from your CI/CD pipeline and searching code repositories)
-- Guide the agent in using your custom MCP server tools effectively for infrastructure-specific workflows
-
-## Available Skills
-
-| Skill | Description | Agent Types | Author | Docs |
-|-------|-------------|-------------|--------|------|
-| [aws-health-events](skills/aws-health-events/) | Retrieves and analyzes AWS Health events (service issues, scheduled changes, account notifications) to identify AWS-side events that correlate with operational issues | Chat tasks, Incident RCA | [udid-aws](https://github.com/udid-aws) | [README](skills/aws-health-events/README.md) |
-| [support-cases](skills/support-cases/) | Searches and analyzes AWS Support cases to find historical incidents with similar symptoms, proven remediations, and recurring patterns | Chat tasks, Incident RCA | [udid-aws](https://github.com/udid-aws) | [README](skills/support-cases/README.md) |
-| [eks-operation-review](skills/eks-operation-review/) | Performs comprehensive Amazon EKS operational reviews aligned with the AWS EKS Best Practices Guide covering security, reliability, networking, and scalability | Chat tasks, Prevention | [yakiratz-aws](https://github.com/yakiratz-aws) | [README](skills/eks-operation-review/README.md) |
-| [rds-operation-review](skills/rds-operation-review/) | Performs comprehensive Amazon RDS operational reviews | Chat tasks, Prevention | [yakiratz-aws](https://github.com/yakiratz-aws) | [README](skills/rds-operation-review/README.md) |
-| [crm-production-investigation-guidelines](skills/crm-production-investigation-guidelines/) | **Sample skill** demonstrating how to write investigation guidelines for the Incident Triage agent type using a fictional CRM application | Incident Triage | [jossaiaws](https://github.com/jossaiaws) | [README](skills/crm-production-investigation-guidelines/README.md) |
-| [skip-scheduled-maintenance](skills/skip-scheduled-maintenance/) | **Sample skill** demonstrating how to skip low-priority incidents during a scheduled maintenance window for the Incident Triage agent type | Incident Triage | [dgorin6](https://github.com/dgorin6) | [README](skills/skip-scheduled-maintenance/README.md) |
-| [enrich-with-aws-security-agent](skills/enrich-with-aws-security-agent/) | Queries AWS Security Agent CloudWatch logs to retrieve code-level security findings (file, line number, vulnerability type) during incident investigations with potential security root causes | Chat tasks, Incident RCA | [yakiratz-aws](https://github.com/yakiratz-aws) | [README](skills/enrich-with-aws-security-agent/README.md) |
-| [investigation-cost-guardrail](skills/investigation-cost-guardrail/) | Estimates the AWS API cost of an incident investigation before any query runs, shows a per-step cost plan, and cancels if the estimate exceeds a configurable threshold | Incident RCA | [inesttia](https://github.com/inesttia) | [README](skills/investigation-cost-guardrail/README.md) |
+**Custom agents** are user-defined AI agents that automate operational tasks specific to your infrastructure. You define a system prompt, assign tools and skills, and run them on demand or on a schedule. See the [DevOps Agent custom agents documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html) for more information.
 
 ## Getting Started
 
-### 1. Clone the repository
-
-Only needed if you plan to upload a skill as a zip file (Option B below) or via the Asset API (Option C below). If you're importing directly from GitHub (Option A), you can skip this step.
-
-```bash
-git clone https://github.com/aws-samples/sample-code-for-devops-agent-skills.git
-cd sample-code-for-devops-agent-skills
-```
-
-### 2. Choose a skill
-
-Browse the skills table above and read the skill's `README.md` for details on its purpose, prerequisites, and sample prompts.
-
-### 3. Upload to AWS DevOps Agent
-
-You can add skills to your Agent Space in three ways:
-
-**Option A: Import from GitHub (recommended)**
-
-If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import skills directly from this repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the skill directory in the repo. The skill stays in sync with the repository. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
-
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
-
-**Option B: Upload as a zip file**
-
-Zip the skill directory (see the zip command in each skill's README) and [upload it via the DevOps Agent web app](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills). Detailed instructions are in each skill's README.
-
-**Option C: Upload via the Asset API**
-
-Use the AWS DevOps Agent Asset API to programmatically manage skills — useful for CI/CD pipelines or automation workflows. See [Managing a skill end-to-end](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-managing-assets.html#managing-a-skill-end-to-end) for the full API workflow.
-
-## Skill Directory Structure
-
-Each skill follows a consistent structure based on the [Agent Skills specification](https://agentskills.io/home):
-
-```
-skills/<skill-name>/
-├── SKILL.md          # Main skill instructions with frontmatter (required)
-├── README.md         # Documentation, prerequisites, and upload guide
-├── CHANGELOG.md      # Version history
-├── evals/            # Evaluation queries and benchmarks
-├── assets/           # Images, diagrams, data files (optional)
-└── references/       # Supplementary reference docs (optional)
-```
-
-The `SKILL.md`, `references/`, and `assets/` directories are what AWS DevOps Agent reads at runtime. Everything else supports development, testing, and documentation.
+See the [Getting Started guide](https://aws-samples.github.io/sample-devops-agent-tools/getting-started/) on the documentation site for step-by-step instructions on deploying skills and custom agents to your Agent Space.
 
 ## Skill Permissions
 
@@ -110,23 +51,6 @@ aws cloudformation deploy \
 
 The template supports enabling/disabling policies per skill, optional region restrictions, and can either attach to an existing role or create a new one. See [`cloudformation/devops-agent-skill-policies.yaml`](cloudformation/devops-agent-skill-policies.yaml) for details.
 
-## Writing Your Own Skills
-
-Want to create custom skills for your operational workflows? See the [AWS DevOps Agent skills documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html) for the full guide, or use the skills in this repository as templates.
-
-Key principles for effective skills (see also the [Agent Skills best practices](https://agentskills.io/skill-creation/best-practices)):
-
-- Decide which agent types in DevOps Agent are relevant for your skill
-- Write a description that specifies when and why the skill should activate — include specific symptoms, services, or error patterns that trigger it
-- Ground instructions in real expertise — specific API patterns, edge cases, and project conventions, not generic advice
-- Keep `SKILL.md` focused and under 500 lines; move detailed reference material to `references/`
-- Add what the agent wouldn't know on its own — omit explanations of general concepts
-- Favor step-by-step procedures over declarative statements so the approach generalizes across tasks
-- Include decision trees for branching scenarios and checklists for multi-step workflows
-- Provide defaults rather than menus — pick a recommended approach and mention alternatives briefly
-- Include a gotchas section for non-obvious facts that defy reasonable assumptions
-- Test with the [Agent Skill Eval](https://github.com/aws-samples/sample-agent-skill-eval) framework, and manually using the DevOps Agent web app, without skill and with skill
-
 ## Contributing
 
 We welcome contributions of new skills and improvements to existing ones. See [CONTRIBUTING](CONTRIBUTING.md) for guidelines.
@@ -139,10 +63,12 @@ We welcome contributions of new skills and improvements to existing ones. See [C
 - [AWS DevOps Agent User Guide](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent.html)
 - [AWS DevOps Agent API Reference](https://docs.aws.amazon.com/devopsagent/latest/APIReference/Welcome.html)
 - [AWS DevOps Agent Skills — Creating and uploading skills](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html)
+- [AWS DevOps Agent Custom Agents](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html)
 
 ### Blog Posts and Articles
 
 - [Extend AWS DevOps Agent with Custom Skills for Your Operational Workflows](https://builder.aws.com/content/3BDdQAFY2bSmtjecZC7vbOQGSEV/extend-aws-devops-agent-with-custom-skills-for-your-operational-workflows)
+- [Resolve Incidents Faster with Skills in AWS DevOps Agent](https://repost.aws/articles/ARMSvRG3qeSVK0qEAoJNsRgQ/resolve-incidents-faster-with-skills-in-aws-devops-agent)
 - [Building an End-to-End Agentic SRE Using AWS DevOps Agent](https://aws.amazon.com/blogs/devops/building-an-end-to-end-agentic-sre-using-aws-devops-agent/)
 - [Best Practices for Deploying AWS DevOps Agent in Production](https://aws.amazon.com/blogs/devops/best-practices-for-deploying-aws-devops-agent-in-production/)
 - [Leverage Agentic AI for Autonomous Incident Response with AWS DevOps Agent](https://aws.amazon.com/blogs/devops/leverage-agentic-ai-for-autonomous-incident-response-with-aws-devops-agent/)
@@ -150,6 +76,7 @@ We welcome contributions of new skills and improvements to existing ones. See [C
 ### Specifications and Tools
 
 - [Agent Skills specification](https://agentskills.io/home) — the open standard this project follows
+- [AGENTS.md specification](https://agents.md/) — the open standard for custom agent definitions
 - [Agent Skill Eval](https://github.com/aws-samples/sample-agent-skill-eval) — evaluation framework for testing skills
 
 ## License

--- a/docs/custom-agents/index.md
+++ b/docs/custom-agents/index.md
@@ -1,0 +1,13 @@
+# Custom Agents Catalog
+
+Browse pre-built custom agent configurations for AWS DevOps Agent. Each agent comes with a system prompt, tool assignments, and skill dependencies ready to deploy.
+
+<div id="agents-catalog-root" data-source="../javascripts/agents-data.json"></div>
+
+## How Custom Agents Work
+
+Custom agents are user-defined AI agents that automate operational tasks specific to your infrastructure. You define a system prompt, assign tools and skills, then run them on demand or on a schedule.
+
+Unlike the built-in DevOps Agent capabilities — which focus on incident response, on-demand queries, and prevention — custom agents let you create purpose-built workflows for recurring operational work such as generating reports, auditing configurations, or orchestrating multi-step procedures.
+
+For more information, see the [AWS DevOps Agent custom agents documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,68 +1,33 @@
 # Getting Started
 
-This guide walks you through deploying a skill from this repository to your AWS DevOps Agent Space.
+This guide walks you through deploying skills and custom agents from this repository to your AWS DevOps Agent Space.
 
 ## Prerequisites
 
 !!! info "Before you begin"
     - An [AWS DevOps Agent Space](https://docs.aws.amazon.com/devopsagent/latest/userguide/getting-started-with-aws-devops-agent-creating-an-agent-space.html) set up with your target AWS account as a cloud source
-    - The skill-specific prerequisites documented on each skill's page (IAM permissions, service plans, etc.)
+    - The skill-specific prerequisites documented on each skill's page (IAM permissions, etc.)
+    - The agent-specific prerequisites documented on each custom agent's page (IAM permissions, tools, skills, etc.)
 
 ---
 
-## Deploy a Skill
+## Skills
 
-### 1. Clone the Repository
+### Deploy a Skill
 
-Only needed if you plan to upload a skill as a zip file (Option B) or via the Asset API (Option C). If you're importing directly from GitHub (Option A), you can skip this step.
+#### 1. Choose a Skill
 
-```bash
-git clone https://github.com/aws-samples/sample-code-for-devops-agent-skills.git
-cd sample-code-for-devops-agent-skills
-```
+Browse the [Skills Catalog](skills/index.md) and select a skill that matches your use case.
 
-### 2. Choose a Skill
+#### 2. Follow the Skill's README
 
-Browse the [available skills](skills/index.md) and review the skill's page for details on its purpose, prerequisites, and sample prompts.
+Each skill's page includes prerequisites, deployment instructions, and sample prompts. Follow the instructions in the skill's README to deploy it to your Agent Space.
 
-### 3. Add the Skill to Your Agent Space
+#### 3. Verify
 
-You can add a skill to your Agent Space in three ways.
+In the DevOps Agent Chat, try one of the sample prompts listed on the skill's page. The agent should automatically activate the skill based on the context of your request.
 
-#### Option A: Import from GitHub (recommended)
-
-If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import a skill directly from this repository — no cloning or packaging required. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the skill's directory (for example, `skills/aws-health-events`) and select the appropriate agent types. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
-
-!!! note
-    You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
-
-#### Option B: Upload as a zip file
-
-From the `skills/` directory, zip the skill for upload:
-
-```bash
-cd skills
-zip -r <skill-name>.zip <skill-name>/ \
-  -i '*.md' '*.txt' '*.json' '*.yaml' '*.yml' '*.xml' '*.csv' '*.tsv' \
-     '*.html' '*.htm' '*.png' '*.jpg' '*.jpeg' '*.gif' '*.svg' '*.webp' '*.pdf' \
-  -x '*/.claude/*' '*/scripts/*' '*/README.md' '*/.skilleval.yaml' \
-     '*/.skilleval.yml' '*/CHANGELOG.md' '*/evals/*'
-```
-
-!!! note
-    The zip excludes evaluation files, READMEs, and changelogs since those are development artifacts — only `SKILL.md`, `references/`, and `assets/` are used by the agent at runtime.
-
-Then upload the zip file via the DevOps Agent web app and select the appropriate agent types. See [Uploading a skill](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) in the AWS DevOps Agent User Guide for detailed steps.
-
-#### Option C: Upload via the Asset API
-
-Use the AWS DevOps Agent Asset API to programmatically manage skills — useful for CI/CD pipelines or automation workflows. Assign the skill to the appropriate agent types. See [Managing a skill end-to-end](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-managing-assets.html#managing-a-skill-end-to-end) for the full API workflow.
-
-### 4. Verify
-
-In the DevOps Agent Chat, try one of the sample prompts listed on the skill's documentation page. The agent should automatically activate the skill based on the context of your request.
-
-## Skill Directory Structure
+### Directory Structure
 
 Each skill follows a consistent structure based on the [Agent Skills specification](https://agentskills.io/home):
 
@@ -78,8 +43,45 @@ skills/<skill-name>/
 
 The `SKILL.md`, `references/`, and `assets/` directories are what AWS DevOps Agent reads at runtime. Everything else supports development, testing, and documentation.
 
-## Writing Your Own Skills
+### Writing Your Own Skills
 
 For guidance on creating custom skills for your operational workflows, see the [AWS DevOps Agent skills documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html).
 
 You can also use the skills in this repository as templates.
+
+---
+
+## Custom Agents
+
+### Deploy a Custom Agent
+
+#### 1. Choose a Custom Agent
+
+Browse the [Custom Agents Catalog](custom-agents/index.md) and select an agent that matches your workflow.
+
+#### 2. Follow the Agent's README
+
+Each custom agent's page includes prerequisites, step-by-step creation instructions, and execution guidance. Follow the instructions in the agent's README to create and configure it in your Agent Space.
+
+#### 3. Verify
+
+Execute the custom agent on-demand from its page in the DevOps Agent web app. Check that the agent produces the expected output (report artifact, recommendations, etc.).
+
+### Directory Structure
+
+Each custom agent follows a consistent structure:
+
+```
+custom-agents/<agent-name>/
+├── SYSTEM_PROMPT.md  # The system prompt to paste into the agent configuration
+├── README.md         # Documentation, prerequisites, creation steps, execution guide
+└── CHANGELOG.md      # Version history
+```
+
+The `SYSTEM_PROMPT.md` is what you paste into the DevOps Agent web app when creating the agent. The README provides the full setup walkthrough.
+
+### Creating Your Own Custom Agents
+
+For guidance on building custom agents for your operational workflows, see the [AWS DevOps Agent custom agents documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html).
+
+You can also use the agents in this repository as templates — they demonstrate how to structure a system prompt, assign tools, and compose skills into a purpose-built workflow.

--- a/docs/hooks/agents_catalog.py
+++ b/docs/hooks/agents_catalog.py
@@ -1,0 +1,271 @@
+"""
+MkDocs hook: generates the custom agents catalog data from README files.
+
+At build time, scans custom-agents/*/README.md, extracts metadata, and writes
+docs/javascripts/agents-data.json. The JS on the catalog page reads this
+JSON to render cards dynamically.
+
+This also generates individual agent doc stubs if a docs/custom-agents/<name>.md
+doesn't already exist, so new agents appear on the site automatically.
+"""
+
+import json
+import re
+from pathlib import Path
+
+
+def on_pre_build(config, **kwargs):
+    """Generate agents-data.json and agent doc stubs before the build."""
+    config_dir = config["docs_dir"].replace("/docs", "")
+    catalog = _build_agents_catalog(config_dir)
+
+    # Write JSON for the JS to consume (only if changed, to avoid dev-server loop)
+    js_dir = Path(config["docs_dir"]) / "javascripts"
+    js_dir.mkdir(parents=True, exist_ok=True)
+    data_path = js_dir / "agents-data.json"
+    new_content = json.dumps(catalog, indent=2)
+    if data_path.is_file() and data_path.read_text(encoding="utf-8") == new_content:
+        pass  # No change, skip write to avoid triggering file watcher
+    else:
+        data_path.write_text(new_content, encoding="utf-8")
+
+    # Generate stub pages for agents that don't have a docs page yet
+    agents_docs_dir = Path(config["docs_dir"]) / "custom-agents"
+    agents_docs_dir.mkdir(parents=True, exist_ok=True)
+
+    for agent in catalog:
+        doc_path = agents_docs_dir / f"{agent['id']}.md"
+        _generate_agent_stub(doc_path, agent, config_dir)
+
+    # Inject agent pages into nav in memory
+    _update_nav(config, catalog)
+
+
+def _build_agents_catalog(config_dir: str) -> list:
+    """Scan all custom agents and build catalog entries."""
+    agents_dir = Path(config_dir) / "custom-agents"
+    catalog = []
+
+    if not agents_dir.is_dir():
+        return catalog
+
+    for agent_path in sorted(agents_dir.iterdir()):
+        if not agent_path.is_dir():
+            continue
+
+        readme = agent_path / "README.md"
+        if not readme.is_file():
+            continue
+
+        readme_text = readme.read_text(encoding="utf-8")
+        lines = readme_text.split("\n")
+
+        # Extract title from first heading (strip " — Custom Agent" suffix)
+        name = _format_name(agent_path.name)
+        for line in lines:
+            if line.startswith("# "):
+                raw_title = line[2:].strip()
+                raw_title = re.sub(r'\s*[—–-]\s*Custom Agent\s*$', '', raw_title)
+                name = raw_title
+                break
+
+        # Extract description from the Purpose section
+        description = _extract_section_first_paragraph(readme_text, "Purpose")
+        if not description:
+            # Fallback: first paragraph after title
+            past_title = False
+            for line in lines:
+                if line.startswith("# "):
+                    past_title = True
+                    continue
+                if past_title and line.strip() and not line.startswith("#"):
+                    description = line.strip()
+                    break
+
+        # Convert markdown links/bold to HTML for card rendering
+        description = re.sub(
+            r'\[([^\]]+)\]\(([^)]+)\)',
+            r'<a href="\2" target="_blank" rel="noopener">\1</a>',
+            description
+        )
+        description = re.sub(
+            r'\*\*([^*]+)\*\*',
+            r'<strong>\1</strong>',
+            description
+        )
+
+        # Extract tools and skills from the README
+        tools = _extract_tools(readme_text)
+        skills = _extract_skills(readme_text)
+
+        catalog.append({
+            "id": agent_path.name,
+            "name": name,
+            "description": description,
+            "tools": tools,
+            "skills": skills,
+        })
+
+    return catalog
+
+
+def _extract_section_first_paragraph(text: str, section_name: str) -> str:
+    """Extract the first paragraph from a named ## section."""
+    pattern = rf'^## {re.escape(section_name)}\s*$'
+    lines = text.split("\n")
+    in_section = False
+    paragraph_lines = []
+
+    for line in lines:
+        if re.match(pattern, line, re.MULTILINE):
+            in_section = True
+            continue
+        if in_section:
+            if line.startswith("## "):
+                break
+            if line.strip() == "" and paragraph_lines:
+                break
+            if line.strip():
+                paragraph_lines.append(line.strip())
+
+    return " ".join(paragraph_lines)
+
+
+def _extract_tools(readme_text: str) -> list:
+    """Extract tool names from the Creating the Agent section."""
+    creating_section = _extract_full_section(readme_text, "Creating the Agent")
+    if creating_section:
+        tool_matches = re.findall(r'`(use_\w+)`', creating_section)
+        return list(dict.fromkeys(tool_matches))  # Dedupe preserving order
+    return []
+
+
+def _extract_skills(readme_text: str) -> list:
+    """Extract skill names from Prerequisites section links."""
+    prereq_section = _extract_full_section(readme_text, "Prerequisites")
+    if prereq_section:
+        skill_matches = re.findall(r'\.\./\.\./skills/([\w-]+)/', prereq_section)
+        return list(dict.fromkeys(skill_matches))
+    return []
+
+
+def _extract_full_section(text: str, section_name: str) -> str:
+    """Extract all text from a named ## section until the next ## heading."""
+    pattern = rf'^## {re.escape(section_name)}\s*$'
+    lines = text.split("\n")
+    in_section = False
+    section_lines = []
+
+    for line in lines:
+        if re.match(pattern, line, re.MULTILINE):
+            in_section = True
+            continue
+        if in_section:
+            if line.startswith("## "):
+                break
+            section_lines.append(line)
+
+    return "\n".join(section_lines)
+
+
+def _format_name(agent_id: str) -> str:
+    """Convert agent-id to display name: aws-health-report -> AWS Health Report."""
+    words = agent_id.split("-")
+    acronyms = {"aws", "eks", "rds", "rca", "mcp", "crm"}
+    return " ".join(
+        w.upper() if w.lower() in acronyms else w.capitalize()
+        for w in words
+    )
+
+
+def _generate_agent_stub(doc_path: Path, agent: dict, config_dir: str):
+    """Generate a custom agent doc page from its README (only if changed)."""
+    repo_url = "https://github.com/aws-samples/sample-devops-agent-tools"
+    github_link = (
+        f'<a href="{repo_url}/tree/main/custom-agents/{agent["id"]}" '
+        f'target="_blank" rel="noopener" class="md-button">'
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" '
+        f'style="vertical-align: text-bottom; margin-right: 0.3rem;">'
+        f'<path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59'
+        f'.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48'
+        f'-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33'
+        f'.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2'
+        f'-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 '
+        f'1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07'
+        f'-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55'
+        f'.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>'
+        f'View on GitHub</a>\n\n'
+    )
+
+    # Build metadata block (tools + skills tags)
+    meta_block = _build_agent_meta_block(agent)
+
+    readme = Path(config_dir) / "custom-agents" / agent["id"] / "README.md"
+    if readme.is_file():
+        readme_content = readme.read_text(encoding="utf-8")
+        # Insert the GitHub link and metadata after the first heading
+        lines = readme_content.split("\n", 1)
+        if len(lines) == 2 and lines[0].startswith("# "):
+            content = lines[0] + "\n\n" + github_link + meta_block + lines[1]
+        else:
+            content = github_link + meta_block + readme_content
+    else:
+        content = f"# {agent['name']}\n\n{github_link}{meta_block}{agent['description']}\n"
+
+    if doc_path.is_file() and doc_path.read_text(encoding="utf-8") == content:
+        return  # No change, skip write
+    doc_path.write_text(content, encoding="utf-8")
+
+
+def _build_agent_meta_block(agent: dict) -> str:
+    """Build an HTML block showing tools and skills tags for an agent page."""
+    tags_html = []
+
+    for tool in agent.get("tools", []):
+        tags_html.append(f'<span class="tag tag-tool">{tool}</span>')
+
+    for skill in agent.get("skills", []):
+        tags_html.append(f'<span class="tag tag-skill">{skill}</span>')
+
+    if tags_html:
+        return (
+            '<div class="skill-page-meta">\n'
+            '<div class="skill-tags">' + " ".join(tags_html) + '</div>\n'
+            '</div>\n\n'
+        )
+    return ""
+
+
+def _update_nav(config, catalog):
+    """Inject custom agent pages into the nav in memory.
+
+    Looks for Custom Agents > Catalog section and appends agent pages there.
+    """
+    nav = config.get("nav")
+    if not nav:
+        return
+
+    for item in nav:
+        if isinstance(item, dict) and "Custom Agents" in item:
+            agents_nav = item["Custom Agents"]
+
+            for entry in agents_nav:
+                if isinstance(entry, dict) and "Catalog" in entry:
+                    catalog_nav = entry["Catalog"]
+
+                    # Collect existing paths
+                    existing_paths = set()
+                    for sub in catalog_nav:
+                        if isinstance(sub, dict):
+                            for path in sub.values():
+                                existing_paths.add(path)
+                        elif isinstance(sub, str):
+                            existing_paths.add(sub)
+
+                    # Add agent pages
+                    for agent in catalog:
+                        page_path = f"custom-agents/{agent['id']}.md"
+                        if page_path not in existing_paths:
+                            catalog_nav.append({agent["name"]: page_path})
+                    break
+            break

--- a/docs/hooks/skills_catalog.py
+++ b/docs/hooks/skills_catalog.py
@@ -1,12 +1,18 @@
 """
-MkDocs hook: generates the skills catalog data from SKILL.md frontmatter.
+MkDocs hook: generates catalog data for skills and custom agents.
 
-At build time, scans skills/*/SKILL.md, extracts metadata, and writes
-docs/javascripts/skills-data.json. The JS on the catalog page reads this
-JSON to render cards and group-by buttons dynamically.
+At build time:
+- Scans skills/*/SKILL.md, extracts metadata, and writes
+  docs/javascripts/skills-data.json.
+- Scans custom-agents/*/README.md, extracts metadata, and writes
+  docs/javascripts/agents-data.json.
 
-This also generates individual skill doc stubs if a docs/skills/<name>.md
-doesn't already exist, so new skills appear on the site automatically.
+The JS on the catalog pages reads these JSON files to render cards
+and group-by buttons dynamically.
+
+This also generates individual doc stubs for skills and custom agents
+that don't have a docs page yet, so new entries appear on the site
+automatically.
 """
 
 import json
@@ -176,7 +182,7 @@ def on_pre_build(config, **kwargs):
 
 def _generate_skill_stub(doc_path: Path, skill: dict, config_dir: str):
     """Generate a minimal skill doc page from its README (only if changed)."""
-    repo_url = "https://github.com/aws-samples/sample-code-for-devops-agent-skills"
+    repo_url = "https://github.com/aws-samples/sample-devops-agent-tools"
     github_link = (
         f'<a href="{repo_url}/tree/main/skills/{skill["id"]}" '
         f'target="_blank" rel="noopener" class="md-button">'

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,12 @@ hide:
   <div class="hero-image">
     <img src="assets/devops-agent-icon.svg" alt="AWS DevOps Agent">
   </div>
-  <h1>AWS DevOps Agent Skills</h1>
-  <p class="hero-subtitle">Extend your DevOps Agent with open-source skills for incident response, root cause analysis, and operational reviews.</p>
+  <h1>AWS DevOps Agent Tools</h1>
+  <p class="hero-subtitle">Open-source skills, custom agents, and infrastructure templates that extend AWS DevOps Agent for incident response, root cause analysis, and operational reviews.</p>
   <div class="hero-buttons">
     <a href="getting-started/" class="md-button md-button--primary">Get Started</a>
     <a href="skills/" class="md-button">Browse Skills</a>
+    <a href="custom-agents/" class="md-button">Browse Custom Agents</a>
   </div>
 </div>
 
@@ -26,6 +27,10 @@ hide:
     <p>Comprehensive best-practices assessments for EKS clusters and RDS databases, generating actionable reports aligned with AWS frameworks.</p>
   </div>
   <div class="feature">
+    <h3>🤖 Custom Agents</h3>
+    <p>Ready-to-use custom agent configurations that combine skills and tools into purpose-built workflows like scheduled health reports.</p>
+  </div>
+  <div class="feature">
     <h3>🧩 Composable</h3>
     <p>Upload multiple skills and the agent activates whichever ones are relevant. Combine investigation and review skills for end-to-end workflows.</p>
   </div>
@@ -33,9 +38,15 @@ hide:
 
 ---
 
-## What Are AWS DevOps Agent Skills?
+## What's in This Repository?
 
-AWS DevOps Agent skills are structured instruction sets that teach the agent how to investigate specific operational scenarios. Skills follow the open [Agent Skills specification](https://agentskills.io/home) and can be uploaded to your DevOps Agent deployment to extend its knowledge beyond built-in capabilities.
+This repository provides open-source tools that extend [AWS DevOps Agent](https://aws.amazon.com/devops-agent/) beyond its built-in capabilities:
+
+- **Skills** — Structured instruction sets that teach the agent how to investigate specific operational scenarios. Skills follow the open [Agent Skills specification](https://agentskills.io/home) and the [DevOps Agent skills](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html) guidance, and can be uploaded to your Agent Space.
+- **Custom Agents** — Pre-built agent configurations with system prompts and tool assignments for specific operational workflows (e.g., generating periodic health reports). Custom agents follow the [AGENTS.md specification](https://agents.md/) and the [DevOps Agent custom agents guidance](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html).
+- **CloudFormation Templates** — Infrastructure-as-code for provisioning IAM permissions and resources that skills require.
+
+### What Can Skills Do?
 
 Skills enable DevOps Agent to:
 
@@ -44,9 +55,21 @@ Skills enable DevOps Agent to:
 - **Compose** multiple skills for end-to-end investigation workflows
 - **Guide** the agent in using your custom MCP server tools effectively for infrastructure-specific workflows
 
+### What Can Custom Agents Do?
+
+Custom agents are user-defined AI agents that automate operational tasks specific to your infrastructure. You define a system prompt, assign tools and skills, and run them on demand or on a schedule. Common use cases include:
+
+- **Operational reporting** — Generate daily or weekly health summaries, deployment reports, or compliance audits across your infrastructure
+- **Configuration auditing** — Periodically check resource configurations against your organization's standards and produce findings
+- **Trend analysis** — Analyze metrics, error patterns, or cost trends over time and surface actionable insights
+- **Multi-step workflows** — Orchestrate sequences of tool calls across multiple integrations to complete complex operational procedures
+- **Cross-tool correlation** — Combine data from observability platforms, CI/CD pipelines, and AWS services to answer complex operational questions
+
 ## Learn More
 
-- [Getting Started](getting-started.md) — how to deploy skills to your Agent Space
+- [Getting Started](getting-started.md) — how to deploy skills and custom agents to your Agent Space
 - [Writing your own skills](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html) — official AWS documentation
+- [Creating custom agents](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html) — official AWS documentation
 - [Agent Skills specification](https://agentskills.io/home) — the open standard these skills follow
+- [AGENTS.md specification](https://agents.md/) — the open standard for custom agent definitions
 - [Agent Skill Eval](https://github.com/aws-samples/sample-agent-skill-eval) — evaluation framework for testing skills

--- a/docs/javascripts/agents-data.json
+++ b/docs/javascripts/agents-data.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "aws-health-report",
+    "name": "AWS Health Report",
+    "description": "This custom agent generates a report of AWS Health events (service issues, scheduled changes, and account notifications) during a specified time period (last 30 days by default). It provides operations teams with visibility into AWS-side events affecting their environment.",
+    "tools": [
+      "use_aws"
+    ],
+    "skills": [
+      "aws-health-events"
+    ]
+  },
+  {
+    "id": "aws-operation-review",
+    "name": "AWS Operation Review",
+    "description": "This custom agent performs comprehensive operational reviews of AWS services (EKS clusters, RDS instances, Aurora clusters) against best practices and the Well-Architected Framework. It identifies gaps in security, reliability, performance, cost optimization, and operational excellence, producing actionable recommendations and a structured report artifact.",
+    "tools": [
+      "use_aws",
+      "use_kubectl"
+    ],
+    "skills": [
+      "eks-operation-review",
+      "rds-operation-review"
+    ]
+  },
+  {
+    "id": "support-cases-report",
+    "name": "Support Cases Report",
+    "description": "This custom agent generates a report of all AWS Support cases during a specified time period (last 60 days by default, unless otherwise requested by a user prompt). It provides operations teams with a consolidated view of support activity, recurring patterns, and items requiring follow-up.",
+    "tools": [
+      "use_aws"
+    ],
+    "skills": [
+      "support-cases"
+    ]
+  }
+]

--- a/docs/javascripts/catalog.js
+++ b/docs/javascripts/catalog.js
@@ -1,16 +1,5 @@
 (function () {
-  function initSkillCatalog() {
-    var container = document.getElementById("skills-catalog-root");
-    if (!container) return;
-
-    var dataUrl = container.getAttribute("data-source");
-    if (!dataUrl) return;
-
-    fetch(dataUrl)
-      .then(function (r) { return r.json(); })
-      .then(function (skills) { render(container, skills); })
-      .catch(function (err) { console.error("Skills catalog:", err); });
-  }
+  // === Shared Utilities ===
 
   function escapeText(str) {
     var div = document.createElement("div");
@@ -25,7 +14,48 @@
     return span;
   }
 
-  function createCard(skill) {
+  function sanitizeHTML(html) {
+    return DOMPurify.sanitize(html, { ALLOWED_TAGS: ["a", "strong"], ALLOWED_ATTR: ["href", "target", "rel"] });
+  }
+
+  function fixRepoLink() {
+    var source = document.querySelector(".md-source");
+    if (source) {
+      source.setAttribute("target", "_blank");
+      source.setAttribute("rel", "noopener");
+    }
+    // Make all external links open in a new tab
+    var siteHost = window.location.hostname;
+    document.querySelectorAll("a[href]").forEach(function (link) {
+      var href = link.getAttribute("href");
+      if (href && href.startsWith("http")) {
+        try {
+          var linkHost = new URL(href).hostname;
+          if (linkHost !== siteHost) {
+            link.setAttribute("target", "_blank");
+            link.setAttribute("rel", "noopener");
+          }
+        } catch (e) {}
+      }
+    });
+  }
+
+  // === Skills Catalog ===
+
+  function initSkillCatalog() {
+    var container = document.getElementById("skills-catalog-root");
+    if (!container) return;
+
+    var dataUrl = container.getAttribute("data-source");
+    if (!dataUrl) return;
+
+    fetch(dataUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (skills) { renderSkills(container, skills); })
+      .catch(function (err) { console.error("Skills catalog:", err); });
+  }
+
+  function createSkillCard(skill) {
     var card = document.createElement("div");
     card.className = "skill-card";
 
@@ -44,7 +74,7 @@
 
     // Description (may contain safe HTML links from the hook)
     var desc = document.createElement("p");
-    desc.innerHTML = DOMPurify.sanitize(skill.description, { ALLOWED_TAGS: ["a", "strong"], ALLOWED_ATTR: ["href", "target", "rel"] });
+    desc.innerHTML = sanitizeHTML(skill.description);
     card.appendChild(desc);
 
     // Author
@@ -78,7 +108,7 @@
     return card;
   }
 
-  function render(container, skills) {
+  function renderSkills(container, skills) {
     // Collect all unique dimension keys
     var dimKeys = [];
     var dimLabels = {};
@@ -128,7 +158,7 @@
     catalogEl.id = "skill-catalog";
     var cards = [];
     skills.forEach(function (skill) {
-      var card = createCard(skill);
+      var card = createSkillCard(skill);
       cards.push(card);
       catalogEl.appendChild(card);
     });
@@ -200,44 +230,79 @@
       .replace(/s$/, "");
   }
 
-  // Initialize
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", function () {
-      initSkillCatalog();
-      fixRepoLink();
+  // === Agents Catalog ===
+
+  function initAgentsCatalog() {
+    var container = document.getElementById("agents-catalog-root");
+    if (!container) return;
+
+    var dataUrl = container.getAttribute("data-source");
+    if (!dataUrl) return;
+
+    fetch(dataUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (agents) { renderAgents(container, agents); })
+      .catch(function (err) { console.error("Agents catalog:", err); });
+  }
+
+  function createAgentCard(agent) {
+    var card = document.createElement("div");
+    card.className = "skill-card";
+
+    // Title with link
+    var h3 = document.createElement("h3");
+    var link = document.createElement("a");
+    link.href = escapeText(agent.id) + "/";
+    link.textContent = agent.name;
+    h3.appendChild(link);
+    card.appendChild(h3);
+
+    // Description
+    var desc = document.createElement("p");
+    desc.innerHTML = sanitizeHTML(agent.description);
+    card.appendChild(desc);
+
+    // Tags (tools + skills)
+    var tagsDiv = document.createElement("div");
+    tagsDiv.className = "skill-tags";
+    (agent.tools || []).forEach(function (tool) {
+      tagsDiv.appendChild(createTag(tool, "tag-tool"));
     });
-  } else {
+    (agent.skills || []).forEach(function (skill) {
+      tagsDiv.appendChild(createTag(skill, "tag-skill"));
+    });
+    card.appendChild(tagsDiv);
+
+    return card;
+  }
+
+  function renderAgents(container, agents) {
+    container.textContent = "";
+
+    var catalogEl = document.createElement("div");
+    catalogEl.id = "agents-catalog";
+    agents.forEach(function (agent) {
+      catalogEl.appendChild(createAgentCard(agent));
+    });
+    container.appendChild(catalogEl);
+  }
+
+  // === Initialize ===
+
+  function initAll() {
     initSkillCatalog();
+    initAgentsCatalog();
     fixRepoLink();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAll);
+  } else {
+    initAll();
   }
 
   // Material instant navigation
   if (typeof document$ !== "undefined") {
-    document$.subscribe(function () {
-      initSkillCatalog();
-      fixRepoLink();
-    });
-  }
-
-  function fixRepoLink() {
-    var source = document.querySelector(".md-source");
-    if (source) {
-      source.setAttribute("target", "_blank");
-      source.setAttribute("rel", "noopener");
-    }
-    // Make all external links open in a new tab
-    var siteHost = window.location.hostname;
-    document.querySelectorAll("a[href]").forEach(function (link) {
-      var href = link.getAttribute("href");
-      if (href && href.startsWith("http")) {
-        try {
-          var linkHost = new URL(href).hostname;
-          if (linkHost !== siteHost) {
-            link.setAttribute("target", "_blank");
-            link.setAttribute("rel", "noopener");
-          }
-        } catch (e) {}
-      }
-    });
+    document$.subscribe(initAll);
   }
 })();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -239,6 +239,38 @@
   color: #2e7d32;
 }
 
+.tag-tool {
+  background: rgba(156, 39, 176, 0.15);
+  color: #ab47bc;
+}
+
+.tag-skill {
+  background: rgba(79, 195, 247, 0.15);
+  color: #4fc3f7;
+}
+
+[data-md-color-scheme="default"] .tag-tool {
+  background: rgba(156, 39, 176, 0.1);
+  color: #7b1fa2;
+}
+
+[data-md-color-scheme="default"] .tag-skill {
+  background: rgba(25, 118, 210, 0.1);
+  color: #1565c0;
+}
+
+#agents-catalog {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  #agents-catalog {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
 .group-heading {
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: AWS DevOps Agent Skills
-site_url: https://aws-samples.github.io/sample-code-for-devops-agent-skills/
-site_description: Open-source skills for AWS DevOps Agent — incident response, root cause analysis, and operational troubleshooting.
-repo_url: https://github.com/aws-samples/sample-code-for-devops-agent-skills
-repo_name: aws-samples/sample-code-for-devops-agent-skills
+site_name: AWS DevOps Agent Tools
+site_url: https://aws-samples.github.io/sample-devops-agent-tools/
+site_description: Open-source skills, custom agents, and templates for AWS DevOps Agent — incident response, root cause analysis, and operational troubleshooting.
+repo_url: https://github.com/aws-samples/sample-devops-agent-tools
+repo_name: aws-samples/sample-devops-agent-tools
 edit_uri: edit/main/docs/
 
 theme:
@@ -40,7 +40,7 @@ extra_css:
 
 extra_javascript:
   - https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js
-  - javascripts/skills-filter.js
+  - javascripts/catalog.js
 
 markdown_extensions:
   - admonition
@@ -66,6 +66,7 @@ plugins:
 
 hooks:
   - docs/hooks/skills_catalog.py
+  - docs/hooks/agents_catalog.py
 
 nav:
   - Home: index.md
@@ -73,9 +74,12 @@ nav:
   - Skills:
       - Catalog:
           - skills/index.md
+  - Custom Agents:
+      - Catalog:
+          - custom-agents/index.md
 
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/aws-samples/sample-code-for-devops-agent-skills
+      link: https://github.com/aws-samples/sample-devops-agent-tools
   generator: false


### PR DESCRIPTION
Updates the GitHub Pages site, README, and steering docs to reflect the repo rename from `sample-code-for-devops-agent-skills` to `sample-devops-agent-tools`, and broadens the scope to cover skills, custom agents, and infrastructure templates.

## Changes

### Repo rename (all files)
- Updated all references to the old repo name across mkdocs.yml, docs, README, steering files, and CLAUDE.md

### Repository-level changes
- **README.md** — Renamed to "AWS DevOps Agent Tools"; removed the "Available Skills" table (replaced with links to docs site catalogs); trimmed "Getting Started" to link to docs site; replaced verbose "What Are Skills" section with concise coverage of both skills and custom agents; removed "Skill Directory Structure" and "Writing Your Own Skills" (covered in docs site); added custom agents and AGENTS.md spec to References
- **`.claude/CLAUDE.md`** — Updated repository structure directory name
- **`.kiro/steering/project-conventions.md`** — Updated repository structure directory name

### GitHub Pages Site - Landing page (docs/index.md)
- Renamed from "AWS DevOps Agent Skills" to "AWS DevOps Agent Tools"
- Added Custom Agents feature card and "Browse Custom Agents" hero button
- New "What's in This Repository?" section covering skills, custom agents, and CloudFormation templates
- Added "What Can Custom Agents Do?" section
- Added links to custom agents docs and AGENTS.md spec

### GitHub Pages Site - Custom Agents catalog (new)
- Added `docs/custom-agents/index.md` catalog page
- Added `docs/hooks/agents_catalog.py` build hook that auto-generates cards and individual pages from `custom-agents/*/README.md`
- Agent cards show extracted tools and skill dependencies as tags

### GitHub Pages Site - JavaScript and CSS
- Renamed `skills-filter.js` → `catalog.js` — now handles both skills and agents catalogs
- Added CSS for agent tag types (`.tag-tool`, `.tag-skill`) and `#agents-catalog` grid

### GitHub Pages Site - Getting Started page (docs/getting-started.md)
- Streamlined deployment steps — each skill/agent's README has the details
- Added parallel "Custom Agents" section with deploy steps and directory structure
- Organized under parent "Skills" and "Custom Agents" headings

## Testing

- `mkdocs build --strict` passes
- Ran `mkdocs serve` and navigated the GitHub Pages site locally, to make sure all changes are reflected and links are working
- All three custom agents auto-detected and rendered in catalog
