### PR TITLE
Add wiz-security-context skill

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@ Skills can be used with these AWS DevOps Agent types:
 - [CRM Production Investigation Guidelines Skill](skills/crm-production-investigation-guidelines/SKILL.md): Sample skill demonstrating how to write production investigation guidelines for the Incident Triage agent type, showing application-specific architecture, incident isolation rules, and structured investigation procedures
 - [Skip Scheduled Maintenance Skill](skills/skip-scheduled-maintenance/SKILL.md): Sample skill demonstrating how to skip low-priority incidents during a scheduled maintenance window, filtering MEDIUM and LOW severity alarms while preserving escalation for HIGH and CRITICAL incidents
 - [Enrich with AWS Security Agent Skill](skills/enrich-with-aws-security-agent/SKILL.md): Queries AWS Security Agent CloudWatch logs to retrieve code-level security findings (file, line number, vulnerability type) during incident investigations with potential security root causes
+- [Wiz Security Context Skill](skills/wiz-security-context/SKILL.md): Queries the Wiz MCP server for a resource's security context (vulnerabilities, misconfigurations, secrets, active threats, malware, toxic combinations) to determine whether an operational anomaly is an operational issue or a security incident
 
 ## Key Concepts
 

--- a/skills/wiz-security-context/.skilleval.yaml
+++ b/skills/wiz-security-context/.skilleval.yaml
@@ -1,0 +1,3 @@
+audit:
+  ignore:
+    - STR-016    # README alongside SKILL.md is intentional

--- a/skills/wiz-security-context/CHANGELOG.md
+++ b/skills/wiz-security-context/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 1.1.0
+
+- Clarified in Prerequisites that all `?toolset=devops` tools are read-only and the full toolset should be allowlisted
+- Streamlined the SKILL.md description to focus on trigger conditions
+
+## 1.0.0
+
+- Initial version

--- a/skills/wiz-security-context/README.md
+++ b/skills/wiz-security-context/README.md
@@ -1,0 +1,99 @@
+# Wiz Security Context
+
+This skill enables the AWS DevOps Agent to query the Wiz MCP server during an operational investigation, adding security context from the Wiz Security Graph so the agent can tell an operational issue apart from a security incident.
+
+## ⚠️ Important Notice
+
+This skill is provided as sample code. It is read-only - it queries the Wiz MCP server for security context and does not take any action on your resources. Before relying on it in production, validate its behavior in a non-production environment and confirm the authenticating Wiz user has only the read permissions it needs.
+
+## Security and Trust
+
+This skill is intentionally a thin stub. Rather than embedding the workflow, it directs AWS DevOps Agent to fetch the current security-auditing workflow from the `devops_resource_auditing_skill` tool on your own Wiz MCP server. That workflow comes from a first-party, trusted source:
+
+- The Wiz MCP server is one you explicitly register, authenticate to via OAuth, and allowlist in your Agent Space - not arbitrary external content.
+- The fetched workflow is read-only guidance for querying Wiz; it drives no changes to your resources.
+- Keeping the workflow server-side lets Wiz maintain and improve it as new capabilities ship, so you always run the current version without updating this skill.
+
+## Purpose
+
+Operational incidents and security incidents often start with the same symptoms. A CPU spike could be a scaling problem or a cryptominer. A latency anomaly could be a bad deployment or data exfiltration. Operational telemetry alone cannot distinguish the two. This skill has the AWS DevOps Agent query Wiz for the affected resource's security context - vulnerabilities, misconfigurations, exposed secrets, data findings, active threats, malware, detections, and toxic combinations - and classify the situation as an operational issue, a security issue, or a Wiz coverage gap, so the right response path is chosen before a human has to switch tools.
+
+## Key Capabilities
+
+- Resolve an affected AWS resource in the Wiz inventory from an ID, ARN, name, or IP
+- Retrieve the resource's security posture: vulnerabilities, misconfigurations, exposed secrets, data findings, active threats, malware, and detections
+- Surface exploitable, internet-exposed, and toxic-combination risks that turn an operational symptom into a likely incident
+- Classify the situation as operational, security-related, or a coverage gap, with the Wiz evidence behind the decision
+- Confirm when a resource is clean, letting the investigation confidently rule out a security cause
+
+## Prerequisites
+
+- A Wiz tenant monitoring the affected AWS account
+- The Wiz MCP server registered in your Agent Space, with the `?toolset=devops` tools allowlisted. Register the endpoint `https://mcp.app.wiz.io/?toolset=devops`, which exposes the `devops_resource_auditing_skill` tool used to fetch the workflow. The fetched workflow directs the agent to call the other `?toolset=devops` tools, so allowlist the full toolset. All of these tools are read-only, so allowlisting the toolset preserves the read-only guarantee
+- OAuth authentication as a Wiz user with permission to read resources, findings, issues, threats, and detections
+
+## Limitations
+
+- This skill is a stub. It depends on the `devops_resource_auditing_skill` tool being available on the connected Wiz MCP server. If the server is unreachable or the tool is not allowlisted, the workflow cannot be fetched
+- Security context is only available for resources monitored by Wiz. Resources not connected to Wiz are reported as a coverage gap
+- Findings are only as current as the most recent Wiz scan of the resource
+- The skill reads security context and classifies the situation; it does not take remediation actions on the resource
+
+## Agent Types
+
+This skill is used by the following agent types:
+
+- **Chat tasks** - conversational security-context lookups for a resource
+- **Incident RCA** - automated root cause analysis where an operational anomaly may have a security cause
+
+## Uploading to AWS DevOps Agent
+
+To deploy this skill to your Agent Space, you can use any of three ways:
+
+**Option A: Import from GitHub (recommended)**
+
+If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/wiz-security-context` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
+
+> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
+
+**Option B: Upload as a zip file**
+
+1. Zip the `wiz-security-context/` directory (only including allowed extensions):
+
+   ```bash
+   cd skills
+   zip -r wiz-security-context.zip wiz-security-context/ -i '*.md' '*.txt' '*.json' '*.yaml' '*.yml' '*.xml' '*.csv' '*.tsv' '*.html' '*.htm' '*.png' '*.jpg' '*.jpeg' '*.gif' '*.svg' '*.webp' '*.pdf' -x '*/.claude/*' '*/scripts/*' '*/README.md' '*/.skilleval.yaml' '*/.skilleval.yml' '*/CHANGELOG.md' '*/evals/*'
+   ```
+
+2. In the AWS DevOps Agent web app, navigate to the **Skills** page.
+3. Click **Add skill** → **Upload skill**.
+4. Drag and drop the `wiz-security-context.zip` file (max 6 MB).
+5. Select the agent types: **Chat tasks** and **Incident RCA**.
+6. Click **Upload**.
+
+**Option C: Upload via the Asset API**
+
+Use the AWS DevOps Agent Asset API to programmatically manage skills - useful for CI/CD pipelines or automation workflows. Assign the skill to the `CHAT` and `INCIDENT_RCA` agent types. See [Managing a skill end-to-end](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-managing-assets.html#managing-a-skill-end-to-end) for the full API workflow.
+
+For more details, see [Uploading a skill](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) in the AWS DevOps Agent User Guide.
+
+## How to Use This Skill
+
+### Chat
+
+- "Is the CPU spike on instance i-0abc123def456789 a security issue or an operational one?"
+- "Check whether the database sending unusual outbound traffic has any active threats or exposed secrets in Wiz."
+- "Does the web server throwing 500 errors have any exploitable, internet-facing vulnerabilities?"
+- "Is this resource monitored by Wiz, and does it have any open critical findings?"
+
+### Investigation
+
+- "Investigate a CPU spike on our backend service - it could be a scaling problem or a compromise."
+- "The checkout service started failing with no recent deployment. Check whether this is security-related."
+- "We're seeing unexpected outbound traffic from an EC2 instance. Determine if it is an operational issue or an active attack."
+- "Latency jumped on an internet-facing service. Rule out a security cause before we scale."
+
+## Learn More
+
+- [Build AI Security Agents with Wiz MCP](https://www.wiz.io/blog/introducing-wiz-mcp)
+- [AWS DevOps Agent Skills documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html)

--- a/skills/wiz-security-context/SKILL.md
+++ b/skills/wiz-security-context/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: wiz-security-context
+description: Automatically load this skill when investigating an operational anomaly on a cloud resource - CPU or memory spikes, latency, elevated error rates, unexpected network traffic, crashes, or cost spikes - to determine whether it is a purely operational issue or a security incident, using the affected resource's security context (vulnerabilities, misconfigurations, exposed secrets, data findings, active threats, malware, detections, and toxic combinations).
+metadata:
+  author: henperez
+  version: "1.1.0"
+  aws-devops-agent-skills.agent-types: "Chat tasks, Incident RCA"
+  aws-devops-agent-skills.aws-services: "Amazon EC2, Amazon ECS, Amazon EKS, Amazon CloudWatch"
+  aws-devops-agent-skills.technical-domains: "Security"
+---
+
+# Add Wiz Security Context to Operational Investigations
+
+Call the `devops_resource_auditing_skill` tool on your connected Wiz MCP server to retrieve the current resource security-auditing workflow, then follow the workflow it returns.
+
+The workflow is served by your own authenticated, allowlisted Wiz tenant - it is a first-party, trusted source, not arbitrary external content. Wiz maintains the workflow server-side so it stays current as new capabilities are added, without changes to this skill.
+
+The workflow directs read-only Wiz queries only. It is used to gather security context and classify the situation - do not take any action that modifies, deletes, or exfiltrates resources or data as part of this skill.
+
+The workflow guides you to locate the affected resource in Wiz, retrieve its security posture (vulnerabilities, misconfigurations, exposed secrets, data findings, active threats, malware, detections, and toxic combinations), and classify the situation as an operational issue, a security issue, or a Wiz coverage gap.
+
+Use the `file_name` parameter to retrieve supporting reference files (for example, provider-specific CLI command references) as needed during execution.
+
+Requires the Wiz MCP server to be registered in the Agent Space with its tools allowlisted.

--- a/skills/wiz-security-context/evals/eval_queries.json
+++ b/skills/wiz-security-context/evals/eval_queries.json
@@ -1,0 +1,22 @@
+[
+  {
+    "query": "How do I set up an S3 bucket lifecycle policy?",
+    "should_trigger": false
+  },
+  {
+    "query": "What are the best practices for DynamoDB table design?",
+    "should_trigger": false
+  },
+  {
+    "query": "Explain how to configure a CloudFront distribution with a custom origin.",
+    "should_trigger": false
+  },
+  {
+    "query": "How do I create a new IAM role for my Lambda function?",
+    "should_trigger": false
+  },
+  {
+    "query": "Write a Terraform module for an Application Load Balancer.",
+    "should_trigger": false
+  }
+]

--- a/skills/wiz-security-context/evals/evals.json
+++ b/skills/wiz-security-context/evals/evals.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "resolve-resource-and-query-posture",
+    "prompt": "Investigate a CPU spike on EC2 instance i-0abc123def456789 - it could be a scaling problem or a compromise.",
+    "expected_output": "The output resolves the resource in Wiz and queries its security posture (findings, vulnerabilities, issues, threats, detections) before concluding whether the anomaly is operational or security-related.",
+    "assertions": [
+      "The output attempts to find the resource in Wiz using an identifier such as the instance ID",
+      "The output queries Wiz for security context such as findings, vulnerabilities, issues, threats, or detections",
+      "The output does not conclude the resource is secure or compromised without citing the Wiz findings behind the decision"
+    ]
+  },
+  {
+    "id": "security-issue-classification",
+    "prompt": "An internet-facing service is showing latency and errors with no recent deployment. Check whether this is a security incident.",
+    "expected_output": "The output checks Wiz for exploitable vulnerabilities, internet exposure, active threats, and toxic combinations, and if found, classifies the situation as a potential security incident with the evidence.",
+    "assertions": [
+      "The output queries Wiz for exploitability, exposure, threats, or toxic combinations on the resource",
+      "The output classifies the situation as operational, security-related, or a coverage gap",
+      "The output includes the specific Wiz findings as evidence when it identifies a security issue"
+    ]
+  },
+  {
+    "id": "operational-issue-when-clean",
+    "prompt": "Check whether the CPU spike on our backend service is security-related.",
+    "expected_output": "The output queries Wiz, and if the resource is monitored with no active findings, reports that the issue is not security-related and recommends continuing the operational investigation.",
+    "assertions": [
+      "The output indicates whether the resource is monitored by Wiz",
+      "The output does not fabricate security findings that Wiz did not return",
+      "The output recommends continuing the operational investigation when no security findings exist"
+    ]
+  },
+  {
+    "id": "coverage-gap-when-not-monitored",
+    "prompt": "Is the resource behind this alert monitored by Wiz, and does it have any security issues?",
+    "expected_output": "The output attempts to find the resource in Wiz, and if it cannot be found after broadening the search, reports a coverage gap rather than assuming the resource is safe.",
+    "assertions": [
+      "The output attempts to locate the resource in Wiz and broadens the search if the first attempt returns nothing",
+      "The output reports a Wiz coverage gap when the resource is not found instead of assuming it is safe",
+      "The output does not fabricate findings for a resource that is not monitored"
+    ]
+  }
+]


### PR DESCRIPTION
Adds `wiz-security-context`, a skill that brings Wiz security context into AWS DevOps Agent investigations.

When an operational anomaly could have a security cause (CPU or memory spikes, latency, error rates, unexpected network traffic, crashes, cost spikes), the skill has the agent query the Wiz MCP server for the affected resource and decide whether the issue is operational, a security incident, or a Wiz coverage gap.

The skill is a thin stub. It calls the `devops_resource_auditing_skill` tool on the operator's own registered, OAuth-authenticated Wiz MCP server to fetch the current security-auditing workflow, then follows it. The workflow is read-only and comes from a first-party, trusted source. Keeping it server-side means it stays current as Wiz adds capabilities, without changing this skill.

**Agent types:** Chat tasks, Incident RCA

**Testing:**
- Passed the Agent Skill Eval audit (100/100, no findings).
- Functional and trigger behavior validated manually in a live DevOps Agent Space connected to a Wiz tenant. Generated eval reports are omitted because they depend on that live, authenticated Wiz MCP connection.

**Also updated:** root README skills table and llms.txt.
