### PR TITLE
fix: replace relative link in DMS README to fix MkDocs deployment

### DIFF
--- a/skills/database-migration-service-expertise/README.md
+++ b/skills/database-migration-service-expertise/README.md
@@ -31,7 +31,7 @@ You need an existing [Agent Space](https://docs.aws.amazon.com/devopsagent/lates
 
 ### 2. IAM permissions for DMS read access
 
-The Agent Space IAM role needs read-only permissions for DMS resources. Nearly all required actions are already covered by the `AIDevOpsAgentAccessPolicy` managed policy attached to the DevOps Agent role. The one exception is `dms:TestConnection`, which must be granted separately — use the [CloudFormation template](../../cloudformation/devops-agent-skill-policies.yaml).
+The Agent Space IAM role needs read-only permissions for DMS resources. Nearly all required actions are already covered by the `AIDevOpsAgentAccessPolicy` managed policy attached to the DevOps Agent role. The one exception is `dms:TestConnection`, which must be granted separately — use the [CloudFormation template](https://github.com/aws-samples/sample-devops-agent-tools/blob/main/cloudformation/devops-agent-skill-policies.yaml).
 
 For reference, the complete action set used by this skill:
 ```json


### PR DESCRIPTION
The documentation deployment failed in MkDocs strict mode because the relative path `../../cloudformation/devops-agent-skill-policies.yaml` doesn't resolve when the README is copied into the generated docs directory.

Replaces it with the absolute GitHub URL.

### Type of change
- [x] Documentation or infrastructure change

### License confirmation
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.