### PR TITLE
Add MCP Servers tab to GitHub Pages site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ docs/skills/*.md
 docs/javascripts/agents-data.json
 docs/custom-agents/*.md
 !docs/custom-agents/index.md
+# Generated at build time by mcp_catalog.py hook
+docs/javascripts/mcp-data.json
+docs/mcp-servers/*.md
+!docs/mcp-servers/index.md
 
 # Claude
 .claude/*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,7 @@ This guide walks you through deploying skills and custom agents from this reposi
     - An [AWS DevOps Agent Space](https://docs.aws.amazon.com/devopsagent/latest/userguide/getting-started-with-aws-devops-agent-creating-an-agent-space.html) set up with your target AWS account as a cloud source
     - The skill-specific prerequisites documented on each skill's page (IAM permissions, etc.)
     - The agent-specific prerequisites documented on each custom agent's page (IAM permissions, tools, skills, etc.)
+    - The server-specific prerequisites documented on each MCP server's page (deployment tools, IAM permissions, etc.)
 
 ---
 
@@ -85,3 +86,47 @@ The `SYSTEM_PROMPT.md` is what you paste into the DevOps Agent web app when crea
 For guidance on building custom agents for your operational workflows, see the [AWS DevOps Agent custom agents documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html).
 
 You can also use the agents in this repository as templates — they demonstrate how to structure a system prompt, assign tools, and compose skills into a purpose-built workflow.
+
+---
+
+## MCP Servers
+
+### Deploy an MCP Server
+
+#### 1. Choose an MCP Server
+
+Browse the [MCP Servers Catalog](mcp-servers/index.md) and select a server that matches your diagnostic needs.
+
+#### 2. Follow the Server's README
+
+Each MCP server's page includes prerequisites, deployment instructions (typically using CDK or SAM), and registration steps for connecting it to your Agent Space.
+
+#### 3. Register with DevOps Agent
+
+After deploying the infrastructure, register the MCP server endpoint with your Agent Space. Each server's README provides the specific registration steps (endpoint URL, authentication method, and tool selection).
+
+#### 4. Verify
+
+In the DevOps Agent Chat, try one of the usage examples from the server's README. The agent should discover and invoke the server's tools based on the context of your request.
+
+### Directory Structure
+
+Each MCP server follows a project-specific structure, but typically includes:
+
+```
+mcp/<server-name>/
+├── README.md         # Documentation, prerequisites, deployment, and registration guide
+├── LICENSE           # License file
+├── template.yaml     # SAM template (or cdk.json for CDK-based servers)
+├── src/              # Server source code
+├── tests/            # Unit and integration tests
+└── docs/             # Architecture and design documentation (optional)
+```
+
+The deployment artifacts (SAM template or CDK app) provision the infrastructure in your AWS account. After deployment, the server exposes an MCP-compatible endpoint that DevOps Agent connects to.
+
+### Building Your Own MCP Servers
+
+For guidance on building MCP servers for DevOps Agent, see the [AWS DevOps Agent MCP servers documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/configuring-integrations-and-knowledge-connecting-mcp-servers.html) and the [Model Context Protocol specification](https://modelcontextprotocol.io).
+
+You can also use the servers in this repository as templates — they demonstrate security models, IAM scoping, tool design patterns, and registration workflows.

--- a/docs/hooks/mcp_catalog.py
+++ b/docs/hooks/mcp_catalog.py
@@ -1,0 +1,215 @@
+"""
+MkDocs hook: generates the MCP servers catalog data from README files.
+
+At build time, scans mcp/*/README.md, extracts metadata, and writes
+docs/javascripts/mcp-data.json. The JS on the catalog page reads this
+JSON to render cards dynamically.
+
+This also generates individual MCP server doc stubs if a docs/mcp-servers/<name>.md
+doesn't already exist, so new servers appear on the site automatically.
+"""
+
+import json
+import re
+from pathlib import Path
+
+
+def on_pre_build(config, **kwargs):
+    """Generate mcp-data.json and MCP server doc stubs before the build."""
+    config_dir = config["docs_dir"].replace("/docs", "")
+    catalog = _build_mcp_catalog(config_dir)
+
+    # Write JSON for the JS to consume (only if changed, to avoid dev-server loop)
+    js_dir = Path(config["docs_dir"]) / "javascripts"
+    js_dir.mkdir(parents=True, exist_ok=True)
+    data_path = js_dir / "mcp-data.json"
+    new_content = json.dumps(catalog, indent=2)
+    if data_path.is_file() and data_path.read_text(encoding="utf-8") == new_content:
+        pass  # No change, skip write to avoid triggering file watcher
+    else:
+        data_path.write_text(new_content, encoding="utf-8")
+
+    # Generate stub pages for MCP servers that don't have a docs page yet
+    mcp_docs_dir = Path(config["docs_dir"]) / "mcp-servers"
+    mcp_docs_dir.mkdir(parents=True, exist_ok=True)
+
+    for server in catalog:
+        doc_path = mcp_docs_dir / f"{server['id']}.md"
+        _generate_mcp_stub(doc_path, server, config_dir)
+
+    # Inject MCP server pages into nav in memory
+    _update_nav(config, catalog)
+
+
+def _build_mcp_catalog(config_dir: str) -> list:
+    """Scan all MCP servers and build catalog entries."""
+    mcp_dir = Path(config_dir) / "mcp"
+    catalog = []
+
+    if not mcp_dir.is_dir():
+        return catalog
+
+    for server_path in sorted(mcp_dir.iterdir()):
+        if not server_path.is_dir():
+            continue
+
+        readme = server_path / "README.md"
+        if not readme.is_file():
+            continue
+
+        readme_text = readme.read_text(encoding="utf-8")
+        lines = readme_text.split("\n")
+
+        # Extract title from first heading
+        name = _format_name(server_path.name)
+        for line in lines:
+            if line.startswith("# "):
+                raw_title = line[2:].strip()
+                # Strip common suffixes like " — MCP", " - MCP Server", etc.
+                raw_title = re.sub(
+                    r'\s*[—–-]\s*MCP\s*(Server)?\s*$', '', raw_title, flags=re.IGNORECASE
+                )
+                name = raw_title
+                break
+
+        # Extract description: first non-blockquote paragraph after the title
+        description = _extract_first_paragraph(lines)
+
+        # Convert markdown links/bold to HTML for card rendering
+        description = re.sub(
+            r'\[([^\]]+)\]\(([^)]+)\)',
+            r'<a href="\2" target="_blank" rel="noopener">\1</a>',
+            description
+        )
+        description = re.sub(
+            r'\*\*([^*]+)\*\*',
+            r'<strong>\1</strong>',
+            description
+        )
+
+        catalog.append({
+            "id": server_path.name,
+            "name": name,
+            "description": description,
+        })
+
+    return catalog
+
+
+def _extract_first_paragraph(lines: list) -> str:
+    """Extract the first non-blockquote paragraph after the title heading."""
+    past_title = False
+    paragraph_lines = []
+
+    for line in lines:
+        if line.startswith("# "):
+            past_title = True
+            continue
+
+        if not past_title:
+            continue
+
+        # Skip blockquote lines
+        if line.startswith(">"):
+            # If we were accumulating a paragraph, stop (shouldn't happen
+            # since blockquotes come before the description)
+            if paragraph_lines:
+                break
+            continue
+
+        # Skip blank lines (before we start accumulating)
+        if not line.strip():
+            if paragraph_lines:
+                break  # End of the paragraph
+            continue
+
+        # Skip sub-headings
+        if line.startswith("#"):
+            if paragraph_lines:
+                break
+            continue
+
+        paragraph_lines.append(line.strip())
+
+    return " ".join(paragraph_lines)
+
+
+def _format_name(server_id: str) -> str:
+    """Convert server-id to display name: aws-eks-node-diagnostics-mcp -> AWS EKS Node Diagnostics MCP."""
+    words = server_id.split("-")
+    acronyms = {"aws", "eks", "rds", "rca", "mcp", "crm", "vpc", "dns"}
+    return " ".join(
+        w.upper() if w.lower() in acronyms else w.capitalize()
+        for w in words
+    )
+
+
+def _generate_mcp_stub(doc_path: Path, server: dict, config_dir: str):
+    """Generate an MCP server doc page from its README (only if changed)."""
+    repo_url = "https://github.com/aws-samples/sample-devops-agent-tools"
+    github_link = (
+        f'<a href="{repo_url}/tree/main/mcp/{server["id"]}" '
+        f'target="_blank" rel="noopener" class="md-button">'
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" '
+        f'style="vertical-align: text-bottom; margin-right: 0.3rem;">'
+        f'<path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59'
+        f'.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48'
+        f'-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33'
+        f'.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2'
+        f'-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 '
+        f'1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07'
+        f'-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55'
+        f'.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>'
+        f'View on GitHub</a>\n\n'
+    )
+
+    readme = Path(config_dir) / "mcp" / server["id"] / "README.md"
+    if readme.is_file():
+        readme_content = readme.read_text(encoding="utf-8")
+        # Insert the GitHub link after the first heading
+        lines = readme_content.split("\n", 1)
+        if len(lines) == 2 and lines[0].startswith("# "):
+            content = lines[0] + "\n\n" + github_link + lines[1]
+        else:
+            content = github_link + readme_content
+    else:
+        content = f"# {server['name']}\n\n{github_link}{server['description']}\n"
+
+    if doc_path.is_file() and doc_path.read_text(encoding="utf-8") == content:
+        return  # No change, skip write
+    doc_path.write_text(content, encoding="utf-8")
+
+
+def _update_nav(config, catalog):
+    """Inject MCP server pages into the nav in memory.
+
+    Looks for MCP Servers > Catalog section and appends server pages there.
+    """
+    nav = config.get("nav")
+    if not nav:
+        return
+
+    for item in nav:
+        if isinstance(item, dict) and "MCP Servers" in item:
+            mcp_nav = item["MCP Servers"]
+
+            for entry in mcp_nav:
+                if isinstance(entry, dict) and "Catalog" in entry:
+                    catalog_nav = entry["Catalog"]
+
+                    # Collect existing paths
+                    existing_paths = set()
+                    for sub in catalog_nav:
+                        if isinstance(sub, dict):
+                            for path in sub.values():
+                                existing_paths.add(path)
+                        elif isinstance(sub, str):
+                            existing_paths.add(sub)
+
+                    # Add MCP server pages
+                    for server in catalog:
+                        page_path = f"mcp-servers/{server['id']}.md"
+                        if page_path not in existing_paths:
+                            catalog_nav.append({server["name"]: page_path})
+                    break
+            break

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,30 +9,27 @@ hide:
     <img src="assets/devops-agent-icon.svg" alt="AWS DevOps Agent">
   </div>
   <h1>AWS DevOps Agent Tools</h1>
-  <p class="hero-subtitle">Open-source skills, custom agents, and infrastructure templates that extend AWS DevOps Agent for incident response, root cause analysis, and operational reviews.</p>
+  <p class="hero-subtitle">Open-source skills, custom agents, MCP servers, and infrastructure templates that extend AWS DevOps Agent for incident response, root cause analysis, and operational reviews.</p>
   <div class="hero-buttons">
     <a href="getting-started/" class="md-button md-button--primary">Get Started</a>
     <a href="skills/" class="md-button">Browse Skills</a>
     <a href="custom-agents/" class="md-button">Browse Custom Agents</a>
+    <a href="mcp-servers/" class="md-button">Browse MCP Servers</a>
   </div>
 </div>
 
 <div class="features">
   <div class="feature">
-    <h3>🔍 Incident Investigation</h3>
-    <p>Skills that search AWS Health events and Support case history to surface root causes and correlations during active incidents.</p>
-  </div>
-  <div class="feature">
-    <h3>🛡️ Operational Reviews</h3>
-    <p>Comprehensive best-practices assessments for EKS clusters and RDS databases, generating actionable reports aligned with AWS frameworks.</p>
+    <h3>🔍 Skills</h3>
+    <p>Structured instruction sets that teach the agent how to investigate incidents, perform operational reviews, and follow best practices for specific AWS services.</p>
   </div>
   <div class="feature">
     <h3>🤖 Custom Agents</h3>
     <p>Ready-to-use custom agent configurations that combine skills and tools into purpose-built workflows like scheduled health reports.</p>
   </div>
   <div class="feature">
-    <h3>🧩 Composable</h3>
-    <p>Upload multiple skills and the agent activates whichever ones are relevant. Combine investigation and review skills for end-to-end workflows.</p>
+    <h3>🔧 MCP Servers</h3>
+    <p>Deployable MCP servers that give the agent custom tools for deep infrastructure diagnostics — node log collection, DNS resolution probing, database health checks, and more.</p>
   </div>
 </div>
 
@@ -44,6 +41,7 @@ This repository provides open-source tools that extend [AWS DevOps Agent](https:
 
 - **Skills** — Structured instruction sets that teach the agent how to investigate specific operational scenarios. Skills follow the open [Agent Skills specification](https://agentskills.io/home) and the [DevOps Agent skills](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html) guidance, and can be uploaded to your Agent Space.
 - **Custom Agents** — Pre-built agent configurations with system prompts and tool assignments for specific operational workflows (e.g., generating periodic health reports). Custom agents follow the [AGENTS.md specification](https://agents.md/) and the [DevOps Agent custom agents guidance](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html).
+- **MCP Servers** — Deployable [Model Context Protocol](https://modelcontextprotocol.io) servers that extend DevOps Agent with custom tools for infrastructure diagnostics, database health checks, and more. Each server is deployed to your AWS account and registered with your Agent Space.
 - **CloudFormation Templates** — Infrastructure-as-code for provisioning IAM permissions and resources that skills require.
 
 ### What Can Skills Do?
@@ -65,6 +63,15 @@ Custom agents are user-defined AI agents that automate operational tasks specifi
 - **Multi-step workflows** — Orchestrate sequences of tool calls across multiple integrations to complete complex operational procedures
 - **Cross-tool correlation** — Combine data from observability platforms, CI/CD pipelines, and AWS services to answer complex operational questions
 
+### What Can MCP Servers Do?
+
+MCP ([Model Context Protocol](https://modelcontextprotocol.io)) is an open standard for connecting AI applications to external systems. MCP servers give DevOps Agent the ability to interact with your infrastructure through custom tools. Use cases include:
+
+- **Deep infrastructure diagnostics** — Collect and analyze node-level logs, DNS resolution behavior, or database internals that aren't accessible through standard AWS APIs
+- **Safe, scoped access** — Each server enforces its own security model with IAM scoping, allowlists, and read-only constraints so the agent operates within well-defined boundaries
+- **Standardized integration** — Build once using the MCP specification and register with DevOps Agent via a secure endpoint — no custom client code needed
+- **Composable with skills** — Pair MCP servers with skills that guide the agent on when and how to use the tools effectively
+
 ## Learn More
 
 - [Getting Started](getting-started.md) — how to deploy skills and custom agents to your Agent Space
@@ -72,4 +79,5 @@ Custom agents are user-defined AI agents that automate operational tasks specifi
 - [Creating custom agents](https://docs.aws.amazon.com/devopsagent/latest/userguide/working-with-devops-agent-custom-agents-index.html) — official AWS documentation
 - [Agent Skills specification](https://agentskills.io/home) — the open standard these skills follow
 - [AGENTS.md specification](https://agents.md/) — the open standard for custom agent definitions
+- [Model Context Protocol](https://modelcontextprotocol.io) — the open specification for MCP servers
 - [Agent Skill Eval](https://github.com/aws-samples/sample-agent-skill-eval) — evaluation framework for testing skills

--- a/docs/javascripts/catalog.js
+++ b/docs/javascripts/catalog.js
@@ -67,7 +67,9 @@
     // Title with link
     var h3 = document.createElement("h3");
     var link = document.createElement("a");
-    link.href = escapeText(skill.id) + "/";
+    var rawId = String(skill && skill.id != null ? skill.id : "");
+    var safeId = /^[A-Za-z0-9_-]+$/.test(rawId) ? rawId : ".";
+    link.href = encodeURIComponent(safeId) + "/";
     link.textContent = skill.name;
     h3.appendChild(link);
     card.appendChild(h3);
@@ -252,7 +254,9 @@
     // Title with link
     var h3 = document.createElement("h3");
     var link = document.createElement("a");
-    link.href = escapeText(agent.id) + "/";
+    var rawId = String(agent && agent.id != null ? agent.id : "");
+    var safeId = /^[A-Za-z0-9_-]+$/.test(rawId) ? rawId : ".";
+    link.href = encodeURIComponent(safeId) + "/";
     link.textContent = agent.name;
     h3.appendChild(link);
     card.appendChild(h3);
@@ -309,7 +313,9 @@
     // Title with link
     var h3 = document.createElement("h3");
     var link = document.createElement("a");
-    link.href = escapeText(server.id) + "/";
+    var rawId = String(server && server.id != null ? server.id : "");
+    var safeId = /^[A-Za-z0-9_-]+$/.test(rawId) ? rawId : ".";
+    link.href = encodeURIComponent(safeId) + "/";
     link.textContent = server.name;
     h3.appendChild(link);
     card.appendChild(h3);

--- a/docs/javascripts/catalog.js
+++ b/docs/javascripts/catalog.js
@@ -287,11 +287,58 @@
     container.appendChild(catalogEl);
   }
 
+  // === MCP Servers Catalog ===
+
+  function initMcpCatalog() {
+    var container = document.getElementById("mcp-catalog-root");
+    if (!container) return;
+
+    var dataUrl = container.getAttribute("data-source");
+    if (!dataUrl) return;
+
+    fetch(dataUrl)
+      .then(function (r) { return r.json(); })
+      .then(function (servers) { renderMcpServers(container, servers); })
+      .catch(function (err) { console.error("MCP servers catalog:", err); });
+  }
+
+  function createMcpCard(server) {
+    var card = document.createElement("div");
+    card.className = "skill-card";
+
+    // Title with link
+    var h3 = document.createElement("h3");
+    var link = document.createElement("a");
+    link.href = escapeText(server.id) + "/";
+    link.textContent = server.name;
+    h3.appendChild(link);
+    card.appendChild(h3);
+
+    // Description
+    var desc = document.createElement("p");
+    desc.innerHTML = sanitizeHTML(server.description);
+    card.appendChild(desc);
+
+    return card;
+  }
+
+  function renderMcpServers(container, servers) {
+    container.textContent = "";
+
+    var catalogEl = document.createElement("div");
+    catalogEl.id = "mcp-catalog";
+    servers.forEach(function (server) {
+      catalogEl.appendChild(createMcpCard(server));
+    });
+    container.appendChild(catalogEl);
+  }
+
   // === Initialize ===
 
   function initAll() {
     initSkillCatalog();
     initAgentsCatalog();
+    initMcpCatalog();
     fixRepoLink();
   }
 

--- a/docs/mcp-servers/index.md
+++ b/docs/mcp-servers/index.md
@@ -1,0 +1,13 @@
+# MCP Servers Catalog
+
+Browse MCP servers that extend AWS DevOps Agent with custom tools for diagnostics, monitoring, and operational tasks. Each server is deployed to your AWS account and registered with your Agent Space.
+
+<div id="mcp-catalog-root" data-source="../javascripts/mcp-data.json"></div>
+
+## How MCP Servers Work
+
+MCP ([Model Context Protocol](https://modelcontextprotocol.io)) servers provide tools to AWS DevOps Agent through a standardized protocol. Unlike skills — which teach the agent *what to do* — MCP servers give the agent *the ability to act* by exposing callable tools that interact with your infrastructure.
+
+Each MCP server is deployed as infrastructure in your AWS account (typically Lambda-based) and registered with DevOps Agent via a secure endpoint. The agent discovers available tools at runtime and invokes them as needed during investigations or operational workflows.
+
+For more information, see the [AWS DevOps Agent MCP servers documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/configuring-integrations-and-knowledge-connecting-mcp-servers.html).

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -259,14 +259,16 @@
   color: #1565c0;
 }
 
-#agents-catalog {
+#agents-catalog,
+#mcp-catalog {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
 }
 
 @media (min-width: 768px) {
-  #agents-catalog {
+  #agents-catalog,
+  #mcp-catalog {
     grid-template-columns: repeat(2, 1fr);
   }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ plugins:
 hooks:
   - docs/hooks/skills_catalog.py
   - docs/hooks/agents_catalog.py
+  - docs/hooks/mcp_catalog.py
 
 nav:
   - Home: index.md
@@ -77,6 +78,9 @@ nav:
   - Custom Agents:
       - Catalog:
           - custom-agents/index.md
+  - MCP Servers:
+      - Catalog:
+          - mcp-servers/index.md
 
 extra:
   social:


### PR DESCRIPTION
- Add mcp_catalog.py hook that scans mcp/*/README.md at build time
- Add MCP Servers catalog index page with dynamic card rendering
- Extend catalog.js with MCP server card rendering
- Add #mcp-catalog CSS grid layout
- Add MCP Servers nav entry and homepage references
- Add .gitignore entries for generated MCP files

<!--
Thank you for your contribution! Please provide a clear description of your change below.
See CONTRIBUTING.md for guidance on contributing skills, custom agents, and tests.
-->

## Description

<!-- What does this PR add or change, and why? -->

## Type of change

- [ ] New skill
- [ ] New custom agent
- [ ] Update to an existing skill or agent
- [X] Documentation or infrastructure change

## Testing

<!-- How did you validate this change? For skills, include Agent Skill Eval results and manual DevOps Agent testing. -->
This is a change for the GitHub Pages site. I validated it by running `mkdocs server` and browsing through the site to make sure the changes work and there are no regressions.
For the reviewer to review the changes locally, including running a local version of the GitHub Pages site, follow the below:
```bash
# Check out the branch
git fetch origin
git checkout docs/add-mcp-servers-section

# Install dependencies (if not already installed)
pip install mkdocs-material

# Preview the site locally
mkdocs serve
```

## License confirmation

- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.
