### PR TITLE
Fix strict build: rewrite relative links in MCP server stubs

### DIFF
--- a/docs/hooks/mcp_catalog.py
+++ b/docs/hooks/mcp_catalog.py
@@ -175,6 +175,16 @@ def _generate_mcp_stub(doc_path: Path, server: dict, config_dir: str):
     else:
         content = f"# {server['name']}\n\n{github_link}{server['description']}\n"
 
+    # Rewrite relative markdown links to absolute GitHub URLs so that
+    # mkdocs --strict does not fail on unresolvable paths like
+    # docs/ARCHITECTURE.md or LICENSE.
+    base = f"{repo_url}/blob/main/mcp/{server['id']}/"
+    content = re.sub(
+        r'\[([^\]]+)\]\((?!https?://|#|\.\./)([^)]+)\)',
+        lambda m: f'[{m.group(1)}]({base}{m.group(2).lstrip("./")})' ,
+        content,
+    )
+
     if doc_path.is_file() and doc_path.read_text(encoding="utf-8") == content:
         return  # No change, skip write
     doc_path.write_text(content, encoding="utf-8")


### PR DESCRIPTION
MCP server READMEs contain relative links (docs/ARCHITECTURE.md, LICENSE) that don't resolve within the docs site. Rewrite them to absolute GitHub URLs when generating stub pages, so mkdocs --strict no longer aborts on unresolvable link warnings.

<!--
Thank you for your contribution! Please provide a clear description of your change below.
See CONTRIBUTING.md for guidance on contributing skills, custom agents, and tests.
-->

## Description

<!-- What does this PR add or change, and why? -->

## Type of change

- [ ] New skill
- [ ] New custom agent
- [ ] Update to an existing skill or agent
- [X] Documentation or infrastructure change

## Testing

<!-- How did you validate this change? For skills, include Agent Skill Eval results and manual DevOps Agent testing. -->

This is a change for the GitHub Pages site. I validated it by running mkdocs server and browsing through the site to make sure the changes work and there are no regressions.
For the reviewer to review the changes locally, including running a local version of the GitHub Pages site, follow the below:
```bash
# Check out the branch
git fetch origin
git checkout docs/add-mcp-servers-section

# Install dependencies (if not already installed)
pip install mkdocs-material

# Preview the site locally
mkdocs serve
```

## License confirmation

- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.
