### PR TITLE
Add mcp and custom-agents README paths to docs deploy trigger

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -9,6 +9,8 @@ on:
       - 'mkdocs.yml'
       - 'skills/*/SKILL.md'
       - 'skills/*/README.md'
+      - 'mcp/*/README.md'
+      - 'custom-agents/*/README.md'
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Description

Adds  `mcp/*/README.md` and `custom-agents/*/README.md` to the `Deploy Documentation` Action workflow's path filter, so future changes to those READMEs will auto-trigger the GitHub Pages docs deploy.

## Type of change

- [ ] New skill
- [ ] New custom agent
- [ ] Update to an existing skill or agent
- [X] Documentation or infrastructure change

## Testing

<!-- How did you validate this change? For skills, include Agent Skill Eval results and manual DevOps Agent testing. -->

## License confirmation

- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.
