### PR TITLE
Update repo and docs URLs from aws-samples to aws org

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ See the [LICENSE](LICENSE) file for terms of use.
 
 This repository contains:
 
-- **Skills** — Domain-specific knowledge, decision trees, and step-by-step runbooks that the agent follows during investigations. Use them as-is or as templates for writing your own. Browse the [Skills Catalog](https://aws-samples.github.io/sample-devops-agent-tools/skills/).
-- **Custom Agents** — Pre-built agent configurations with system prompts and tool assignments for recurring operational workflows like health reports and operational reviews. Browse the [Custom Agents Catalog](https://aws-samples.github.io/sample-devops-agent-tools/custom-agents/).
+- **Skills** — Domain-specific knowledge, decision trees, and step-by-step runbooks that the agent follows during investigations. Use them as-is or as templates for writing your own. Browse the [Skills Catalog](https://aws.github.io/tools-for-devops-agent/skills/).
+- **Custom Agents** — Pre-built agent configurations with system prompts and tool assignments for recurring operational workflows like health reports and operational reviews. Browse the [Custom Agents Catalog](https://aws.github.io/tools-for-devops-agent/custom-agents/).
 - **CloudFormation Templates** — Infrastructure-as-code for provisioning IAM permissions that skills require.
 
 All tools are contributed and tested according to the [contribution guidelines](CONTRIBUTING.md).
@@ -33,7 +33,7 @@ All tools are contributed and tested according to the [contribution guidelines](
 
 ## Getting Started
 
-See the [Getting Started guide](https://aws-samples.github.io/sample-devops-agent-tools/getting-started/) on the documentation site for step-by-step instructions on deploying skills and custom agents to your Agent Space.
+See the [Getting Started guide](https://aws.github.io/tools-for-devops-agent/getting-started/) on the documentation site for step-by-step instructions on deploying skills and custom agents to your Agent Space.
 
 ## Skill Permissions
 

--- a/docs/hooks/agents_catalog.py
+++ b/docs/hooks/agents_catalog.py
@@ -180,7 +180,7 @@ def _format_name(agent_id: str) -> str:
 
 def _generate_agent_stub(doc_path: Path, agent: dict, config_dir: str):
     """Generate a custom agent doc page from its README (only if changed)."""
-    repo_url = "https://github.com/aws-samples/sample-devops-agent-tools"
+    repo_url = "https://github.com/aws/tools-for-devops-agent"
     github_link = (
         f'<a href="{repo_url}/tree/main/custom-agents/{agent["id"]}" '
         f'target="_blank" rel="noopener" class="md-button">'

--- a/docs/hooks/mcp_catalog.py
+++ b/docs/hooks/mcp_catalog.py
@@ -146,7 +146,7 @@ def _format_name(server_id: str) -> str:
 
 def _generate_mcp_stub(doc_path: Path, server: dict, config_dir: str):
     """Generate an MCP server doc page from its README (only if changed)."""
-    repo_url = "https://github.com/aws-samples/sample-devops-agent-tools"
+    repo_url = "https://github.com/aws/tools-for-devops-agent"
     github_link = (
         f'<a href="{repo_url}/tree/main/mcp/{server["id"]}" '
         f'target="_blank" rel="noopener" class="md-button">'

--- a/docs/hooks/skills_catalog.py
+++ b/docs/hooks/skills_catalog.py
@@ -182,7 +182,7 @@ def on_pre_build(config, **kwargs):
 
 def _generate_skill_stub(doc_path: Path, skill: dict, config_dir: str):
     """Generate a minimal skill doc page from its README (only if changed)."""
-    repo_url = "https://github.com/aws-samples/sample-devops-agent-tools"
+    repo_url = "https://github.com/aws/tools-for-devops-agent"
     github_link = (
         f'<a href="{repo_url}/tree/main/skills/{skill["id"]}" '
         f'target="_blank" rel="noopener" class="md-button">'

--- a/mcp/aws-vpc-dns-diagnostics-mcp/CHANGELOG.md
+++ b/mcp/aws-vpc-dns-diagnostics-mcp/CHANGELOG.md
@@ -53,4 +53,4 @@ Initial release.
   resolution engine, all six trap detectors, opaque-marker handling, and runbook
   catalogue integrity.
 
-[1.0.0]: https://github.com/aws-samples/sample-devops-agent-tools
+[1.0.0]: https://github.com/aws/tools-for-devops-agent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: AWS DevOps Agent Tools
-site_url: https://aws-samples.github.io/sample-devops-agent-tools/
+site_url: https://aws.github.io/tools-for-devops-agent/
 site_description: Open-source skills, custom agents, and templates for AWS DevOps Agent — incident response, root cause analysis, and operational troubleshooting.
-repo_url: https://github.com/aws-samples/sample-devops-agent-tools
-repo_name: aws-samples/sample-devops-agent-tools
+repo_url: https://github.com/aws/tools-for-devops-agent
+repo_name: aws/tools-for-devops-agent
 edit_uri: edit/main/docs/
 
 theme:
@@ -85,5 +85,5 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/aws-samples/sample-devops-agent-tools
+      link: https://github.com/aws/tools-for-devops-agent
   generator: false

--- a/skills/aws-health-events/README.md
+++ b/skills/aws-health-events/README.md
@@ -40,7 +40,7 @@ You can add this skill to your Agent Space in three ways:
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/aws-health-events` directory. When prompted, select the agent types: **Chat tasks** and **Incident RCA**. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/aws-vpc-dns-investigation/README.md
+++ b/skills/aws-vpc-dns-investigation/README.md
@@ -1,7 +1,7 @@
 # AWS VPC DNS Investigation
 
 This skill tells the AWS DevOps Agent when to reach for the
-[aws-vpc-dns-diagnostics MCP server](https://github.com/aws-samples/sample-devops-agent-tools/tree/main/mcp/aws-vpc-dns-diagnostics-mcp) and in
+[aws-vpc-dns-diagnostics MCP server](https://github.com/aws/tools-for-devops-agent/tree/main/mcp/aws-vpc-dns-diagnostics-mcp) and in
 what order to use its tools, so a cold symptom like "this name will not resolve"
 leads to a consistent investigation instead of an ad hoc one.
 
@@ -43,7 +43,7 @@ between resolvers is not the same as correctness.
 
 - The `aws-vpc-dns-diagnostics` MCP server registered in your Agent Space with its
   tools allowlisted. The server and its deployment instructions are in this
-  repository at [`mcp/aws-vpc-dns-diagnostics-mcp/`](https://github.com/aws-samples/sample-devops-agent-tools/tree/main/mcp/aws-vpc-dns-diagnostics-mcp)
+  repository at [`mcp/aws-vpc-dns-diagnostics-mcp/`](https://github.com/aws/tools-for-devops-agent/tree/main/mcp/aws-vpc-dns-diagnostics-mcp)
 - The scoped IAM roles deployed in each target account, and those account IDs
   supplied in the server's `AllowedAccounts` parameter. There is no default and a
   wildcard is refused
@@ -120,6 +120,6 @@ Assign the skill to the `CHAT` and `INCIDENT_RCA` agent types. See
 
 ## Learn More
 
-- [aws-vpc-dns-diagnostics MCP server](https://github.com/aws-samples/sample-devops-agent-tools/blob/main/mcp/aws-vpc-dns-diagnostics-mcp/README.md)
-- [Architecture](https://github.com/aws-samples/sample-devops-agent-tools/blob/main/mcp/aws-vpc-dns-diagnostics-mcp/docs/ARCHITECTURE.md)
+- [aws-vpc-dns-diagnostics MCP server](https://github.com/aws/tools-for-devops-agent/blob/main/mcp/aws-vpc-dns-diagnostics-mcp/README.md)
+- [Architecture](https://github.com/aws/tools-for-devops-agent/blob/main/mcp/aws-vpc-dns-diagnostics-mcp/docs/ARCHITECTURE.md)
 - [AWS DevOps Agent Skills documentation](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html)

--- a/skills/crm-production-investigation-guidelines/README.md
+++ b/skills/crm-production-investigation-guidelines/README.md
@@ -42,7 +42,7 @@ To deploy this skill (or your adapted version) to your Agent Space, you can use 
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/crm-production-investigation-guidelines` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/database-migration-service-expertise/README.md
+++ b/skills/database-migration-service-expertise/README.md
@@ -31,7 +31,7 @@ You need an existing [Agent Space](https://docs.aws.amazon.com/devopsagent/lates
 
 ### 2. IAM permissions for DMS read access
 
-The Agent Space IAM role needs read-only permissions for DMS resources. Nearly all required actions are already covered by the `AIDevOpsAgentAccessPolicy` managed policy attached to the DevOps Agent role. The one exception is `dms:TestConnection`, which must be granted separately — use the [CloudFormation template](https://github.com/aws-samples/sample-devops-agent-tools/blob/main/cloudformation/devops-agent-skill-policies.yaml).
+The Agent Space IAM role needs read-only permissions for DMS resources. Nearly all required actions are already covered by the `AIDevOpsAgentAccessPolicy` managed policy attached to the DevOps Agent role. The one exception is `dms:TestConnection`, which must be granted separately — use the [CloudFormation template](https://github.com/aws/tools-for-devops-agent/blob/main/cloudformation/devops-agent-skill-policies.yaml).
 
 For reference, the complete action set used by this skill:
 ```json

--- a/skills/database-rds-devops/README.md
+++ b/skills/database-rds-devops/README.md
@@ -72,7 +72,7 @@ ec2:DescribeSecurityGroups
 Layers 1 and 2 work with no additional infrastructure. Database-internal diagnostics
 require the **`rds-aidba`** MCP server, co-located in this repository at `mcp/rds-aidba/`.
 
-- **Setup guide:** [`references/mcp-setup.md`](https://github.com/aws-samples/sample-devops-agent-tools/blob/main/skills/database-rds-devops/references/mcp-setup.md)
+- **Setup guide:** [`references/mcp-setup.md`](https://github.com/aws/tools-for-devops-agent/blob/main/skills/database-rds-devops/references/mcp-setup.md)
 - **Transport:** Streamable HTTP over a Lambda Function URL
 - **Authentication:** AWS SigV4 (service name `lambda`)
 - **Caller permissions:** `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` on the
@@ -128,7 +128,7 @@ To deploy this skill to your Agent Space, you can use any of three ways:
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/database-rds-devops` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/investigation-cost-guardrail/README.md
+++ b/skills/investigation-cost-guardrail/README.md
@@ -285,7 +285,7 @@ Add the skill to your Agent Space and adjust the threshold to match your organiz
 
 **Option A:** Fork or copy the skill into your own GitHub repository and import it directly into your Agent Space via the GitHub integration. This lets you version and customize the skill independently.
 
-**Option B:** Download the `.zip` directly from the [repository](https://github.com/aws-samples/sample-devops-agent-tools/tree/main/skills/investigation-cost-guardrail) and upload it as a skill in your Agent Space.
+**Option B:** Download the `.zip` directly from the [repository](https://github.com/aws/tools-for-devops-agent/tree/main/skills/investigation-cost-guardrail) and upload it as a skill in your Agent Space.
 
 ## Known Limitations
 

--- a/skills/msk-operations/README.md
+++ b/skills/msk-operations/README.md
@@ -49,7 +49,7 @@ The AWS DevOps Agent's primary cloud-source role needs read access to MSK and
 CloudWatch. All calls except `kafka:GetBootstrapBrokers` are covered by
 `AIDevOpsAgentAccessPolicy`. `kafka:GetBootstrapBrokers` is granted by the
 opt-in `EnableMskOperations` parameter (default `true`) in
-[`cloudformation/devops-agent-skill-policies.yaml`](https://github.com/aws-samples/sample-devops-agent-tools/blob/main/cloudformation/devops-agent-skill-policies.yaml).
+[`cloudformation/devops-agent-skill-policies.yaml`](https://github.com/aws/tools-for-devops-agent/blob/main/cloudformation/devops-agent-skill-policies.yaml).
 The full set of actions the skill uses in practice:
 
 ```

--- a/skills/service-quota-check/README.md
+++ b/skills/service-quota-check/README.md
@@ -45,7 +45,7 @@ To deploy this skill to your Agent Space, you can use any of three ways:
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings -> Add Skill -> Import from repository, then point to the `skills/service-quota-check` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/skip-scheduled-maintenance/README.md
+++ b/skills/skip-scheduled-maintenance/README.md
@@ -42,7 +42,7 @@ To deploy this skill (or your adapted version) to your Agent Space, you can use 
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/skip-scheduled-maintenance` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/storage-s3-resiliency-expertise/README.md
+++ b/skills/storage-s3-resiliency-expertise/README.md
@@ -98,7 +98,7 @@ To deploy this skill to your Agent Space, you can use any of three ways:
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/storage-s3-resiliency-expertise` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/support-cases/README.md
+++ b/skills/support-cases/README.md
@@ -38,7 +38,7 @@ To deploy this skill to your Agent Space, you can use any of three ways:
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/support-cases` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository — including this one — even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 

--- a/skills/wiz-security-context/README.md
+++ b/skills/wiz-security-context/README.md
@@ -54,7 +54,7 @@ To deploy this skill to your Agent Space, you can use any of three ways:
 
 If you have a [GitHub connection configured](https://docs.aws.amazon.com/devopsagent/latest/userguide/connecting-to-cicd-pipelines-connecting-github.html) in your Agent Space, you can import this skill directly from the repository. In the DevOps Agent web app, go to Settings → Add Skill → Import from repository, then point to the `skills/wiz-security-context` directory. See [Importing a skill from a repository](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent-devops-agent-skills.html#creating-skills) for full instructions.
 
-> **Note:** You cannot connect the `aws-samples` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
+> **Note:** You cannot connect the `aws` GitHub organization directly because the GitHub connection setup requires admin rights on the organization. Instead, connect your personal GitHub account and select any repository from it during the connection setup. Once a GitHub connection is established, you can import skills from any public repository, including this one, even if it wasn't selected during the connection setup.
 
 **Option B: Upload as a zip file**
 


### PR DESCRIPTION
## Summary

The repository moved from `aws-samples/sample-devops-agent-tools` to `aws/tools-for-devops-agent` (docs site now at https://aws.github.io/tools-for-devops-agent/). This updates all self-references so the published docs page and READMEs no longer point at the old, now-404'd location.

Changes across 18 files:
- **mkdocs.yml** — `site_url`, `repo_url`, `repo_name`, and the GitHub social link.
- **docs/hooks/*.py** — the `repo_url` constant used to generate per-skill/agent/MCP "View on GitHub" buttons (`tree/main/...`, default branch confirmed `main`).
- **README.md** — Skills Catalog, Custom Agents Catalog, and Getting Started site links.
- **Skill READMEs** — repo blob/tree links and the ``aws-samples`` → ``aws`` GitHub-organization notes in the import instructions.
- **mcp/aws-vpc-dns-diagnostics-mcp/CHANGELOG.md** — release reference link.

## Intentionally unchanged
- `aws-samples/sample-agent-skill-eval` and `aws-samples/sample-eks-node-diagnostics-mcp` — genuinely separate repos, both still live (200).

## Validation
- New site + repo verified live (200); old site verified dead (404), confirming this is a corrective change.
- Untouched separate repos verified still live (200).