### PR TITLE
Add issue forms for tool requests and bugs, with tool-type auto-labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a problem with an existing skill, custom agent, MCP server, or IaC template.
+title: "[bug]: <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug!
+
+        This form is for problems with existing tools — not for suggesting new ones. To propose a new skill, custom agent, or MCP server, use the **Suggest a new tool** template instead.
+
+        > **Security disclosures:** If you think you've found a potential security issue, please do **not** post it here. Follow the instructions at https://aws.amazon.com/security/vulnerability-reporting/ instead.
+
+  - type: input
+    id: affected-tool
+    attributes:
+      label: Which tool is affected?
+      description: Name the skill, custom agent, MCP server, or IaC template (e.g. `support-cases` skill, `rds-aidba` MCP server).
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you observe?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: |
+        A reproducible test case or series of steps. Include the prompt you gave DevOps Agent, if relevant.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Anything unusual about your environment or deployment. Skill/agent version, AWS region, DevOps Agent functionality used (Chat, Incident RCA, etc.).
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or additional context
+      description: Relevant logs, error messages, or screenshots. Remember to remove any personally-identifiable information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,15 +23,15 @@ body:
   - type: textarea
     id: what-happened
     attributes:
-      label: What happened?
-      description: Describe the bug. What did you observe?
+      label: Describe the bug
+      description: What did you observe?
     validations:
       required: true
 
   - type: textarea
     id: expected
     attributes:
-      label: What did you expect to happen?
+      label: Expected behaviour
     validations:
       required: true
 
@@ -51,7 +51,7 @@ body:
   - type: textarea
     id: environment
     attributes:
-      label: Environment
+      label: Environment details
       description: |
         Anything unusual about your environment or deployment. Skill/agent version, AWS region, DevOps Agent functionality used (Chat, Incident RCA, etc.).
     validations:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a problem with an existing skill, custom agent, MCP server, or IaC template.
 title: "[bug]: <short description>"
-labels: ["bug"]
+labels: ["bug", "needs-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/community-request.yml
+++ b/.github/ISSUE_TEMPLATE/community-request.yml
@@ -1,0 +1,117 @@
+name: Suggest a new tool
+description: Suggest a new skill, custom agent, MCP server, IaC template, or other tool for the roadmap. The team will review.
+title: "[request]: <short description>"
+labels: ["request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new tool!
+
+        **Before you file**, please search existing issues, skills, custom agents, and MCP servers to make sure this isn't already covered, and check whether AWS DevOps Agent can already do this natively. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full contribution process.
+
+        ### Community Note
+        * Please vote on this request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue. This helps the team and community prioritize.
+        * Please do not leave "+1" or "me too" comments — they add noise for followers and don't help prioritization.
+        * If you're interested in building this yourself or have opened a pull request, please leave a comment.
+
+        > **Security disclosures:** If you think you've found a potential security issue, please do **not** post it here. Follow the instructions at https://aws.amazon.com/security/vulnerability-reporting/ instead.
+
+  - type: checkboxes
+    id: tool-type
+    attributes:
+      label: What type of tool is this?
+      description: Select all that apply — a request can span more than one (e.g. a skill plus a custom agent that uses it, or a skill plus an MCP server that supports it).
+      options:
+        - label: Skill
+        - label: Custom agent
+        - label: MCP server
+        - label: IaC
+        - label: Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: request
+    attributes:
+      label: Tell us about your request
+      description: What do you want built? A sentence or two is fine.
+    validations:
+      required: true
+
+  - type: input
+    id: aws-services
+    attributes:
+      label: Which AWS service(s) is this for?
+      description: For example Lambda, RDS, EKS, CloudWatch, Health, Support. List all that apply, or "N/A".
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve, and why is it hard?
+      description: |
+        What operational outcome are you after, and why is it hard or impossible today? Describe the scenario an operator would be in when they'd reach for this (e.g. "investigating elevated Lambda error rates", "generating a quarterly support cases report"). What's the impact of not having it? More detail helps us understand and prioritize.
+    validations:
+      required: true
+
+  - type: textarea
+    id: behavior
+    attributes:
+      label: How should it behave?
+      description: |
+        - For a **skill**: what should trigger it, and what steps should it walk through?
+        - For a **custom agent**: what's the intent of its system prompt, and which skills/tools would it assign?
+        - For an **MCP server**: what capabilities or tools would it expose?
+        - For an **IaC template**: what resources or permissions would it provision?
+    validations:
+      required: false
+
+  - type: input
+    id: functionalities
+    attributes:
+      label: Which DevOps Agent functionalities is this relevant to?
+      description: For example Chat tasks, Incident RCA, scheduled agent runs. List all that apply.
+    validations:
+      required: false
+
+  - type: textarea
+    id: permissions
+    attributes:
+      label: Does this need extra permissions?
+      description: Would this require IAM permissions beyond the `AIDevOpsAgentAccessPolicy` and `ReadOnlyAccess` AWS managed policies? If you know the actions/resources, list them. Leave blank if unsure.
+    validations:
+      required: false
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Are you currently working around this?
+      description: How are you solving this today, if at all?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: existing-check
+    attributes:
+      label: Have you checked for existing tools?
+      options:
+        - label: I've searched existing issues, skills, custom agents, and MCP servers, and this isn't already covered or extendable.
+        - label: I've confirmed DevOps Agent can't already do this natively (I tested it).
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Would you like to build it?
+      options:
+        - label: I'm willing to contribute this myself (see CONTRIBUTING.md).
+        - label: I'm suggesting it for someone else to build.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else we should know? Links, docs, example prompts, screenshots. Remember to remove any personally-identifiable information.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/community-request.yml
+++ b/.github/ISSUE_TEMPLATE/community-request.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for suggesting a new tool!
 
-        **Before you file**, please search existing issues, skills, custom agents, and MCP servers to make sure this isn't already covered, and check whether AWS DevOps Agent can already do this natively. See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full contribution process.
+        **Before you file**, please search existing issues, skills, custom agents, and MCP servers to make sure this isn't already covered, and check whether AWS DevOps Agent can already do this natively. See [CONTRIBUTING.md](https://github.com/aws/tools-for-devops-agent/blob/main/CONTRIBUTING.md) for the full contribution process.
 
         ### Community Note
         * Please vote on this request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue. This helps the team and community prioritize.

--- a/.github/ISSUE_TEMPLATE/community-request.yml
+++ b/.github/ISSUE_TEMPLATE/community-request.yml
@@ -1,7 +1,7 @@
 name: Suggest a new tool
 description: Suggest a new skill, custom agent, MCP server, IaC template, or other tool for the roadmap. The team will review.
 title: "[request]: <short description>"
-labels: ["request"]
+labels: ["request", "needs-triage"]
 body:
   - type: markdown
     attributes:
@@ -20,13 +20,13 @@ body:
   - type: checkboxes
     id: tool-type
     attributes:
-      label: What type of tool is this?
+      label: Select the type of tool this is related to
       description: Select all that apply — a request can span more than one (e.g. a skill plus a custom agent that uses it, or a skill plus an MCP server that supports it).
       options:
         - label: Skill
         - label: Custom agent
         - label: MCP server
-        - label: IaC
+        - label: IaC (Infrastructure as Code) template
         - label: Other
     validations:
       required: true
@@ -50,7 +50,7 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: What problem are you trying to solve, and why is it hard?
+      label: What problem are you trying to solve?
       description: |
         What operational outcome are you after, and why is it hard or impossible today? Describe the scenario an operator would be in when they'd reach for this (e.g. "investigating elevated Lambda error rates", "generating a quarterly support cases report"). What's the impact of not having it? More detail helps us understand and prioritize.
     validations:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribution guidelines
+    url: https://github.com/aws/tools-for-devops-agent/blob/main/CONTRIBUTING.md
+    about: Read how to contribute a new skill, custom agent, or MCP server before filing.
+  - name: Security issue
+    url: https://aws.amazon.com/security/vulnerability-reporting/
+    about: Please report potential security issues here, not as a public GitHub issue.

--- a/.github/workflows/label-tool-type.yml
+++ b/.github/workflows/label-tool-type.yml
@@ -28,7 +28,7 @@ jobs:
               { text: "Skill",        label: "skill" },
               { text: "Custom agent", label: "custom-agent" },
               { text: "MCP server",   label: "mcp-server" },
-              { text: "IaC",          label: "iac" },
+              { text: "IaC (Infrastructure as Code) template", label: "iac" },
               { text: "Other",        label: "other" },
             ];
 

--- a/.github/workflows/label-tool-type.yml
+++ b/.github/workflows/label-tool-type.yml
@@ -1,0 +1,56 @@
+name: Label tool-type on requests
+
+# Reads the "What type of tool is this?" checkboxes from the "Suggest a new tool"
+# issue form and applies routing labels (skill / custom-agent / mcp-server / iac / other)
+# so cards land in the matching roadmap tab. Runs only on issues carrying the "request"
+# label, so bug reports and other issues are left untouched.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'request')
+    steps:
+      - name: Apply tool-type labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || "";
+
+            // Map the checkbox label text (as rendered in the issue body) to a repo label.
+            const mapping = [
+              { text: "Skill",        label: "skill" },
+              { text: "Custom agent", label: "custom-agent" },
+              { text: "MCP server",   label: "mcp-server" },
+              { text: "IaC",          label: "iac" },
+              { text: "Other",        label: "other" },
+            ];
+
+            // A checked box renders as "- [x] <text>" (x may be upper/lower case).
+            const isChecked = (text) => {
+              const escaped = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              const re = new RegExp(`^\\s*[-*]\\s*\\[[xX]\\]\\s*${escaped}\\b`, "m");
+              return re.test(body);
+            };
+
+            const toAdd = mapping.filter(m => isChecked(m.text)).map(m => m.label);
+
+            if (toAdd.length === 0) {
+              core.info("No tool-type checkboxes checked; nothing to label.");
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              labels: toAdd,
+            });
+
+            core.info(`Applied labels: ${toAdd.join(", ")}`);


### PR DESCRIPTION
## Description

Adds structured GitHub issue forms and automatic label-based routing to support the roadmap Project (`tools-for-devops-agent-roadmap`).

- **`community-request.yml`** — roadmap intake form for suggesting a new skill, custom agent, MCP server, IaC template, or other tool. Applies the `request` label on submission. Tool-type is a multi-select (a request can span more than one type, e.g. a skill plus a supporting MCP server).
- **`bug-report.yml`** — form for reporting problems with existing tools. Applies the `bug` label. Intentionally kept off the roadmap.
- **`config.yml`** — contact links (Contribution guidelines, Security reporting). Blank issues left enabled.
- **`label-tool-type.yml`** — GitHub Action that reads the request form's tool-type checkboxes and applies routing labels (`skill` / `custom-agent` / `mcp-server` / `iac` / `other`). Gated on the `request` label so it never touches bug reports.

## How routing works

1. Request form applies `request` on submit.
2. The Action adds tool-type labels based on the checked boxes.
3. The Project's Auto-add workflow (filtered to `label:request`) pulls the issue onto the board — bugs and untemplated issues stay off.
4. Each roadmap tab filters by its tool-type label (`label:skill`, etc.). The "All Items" tab stays unfiltered.

## Follow-up (Project UI, not in this PR)

GitHub Project workflows and view filters are configured in the Project UI, not in the repo:
- Auto-add to project → filter `is:issue is:open label:request`
- Item added to project → set Status = Backlog
- Per-tab filters: `label:skill`, `label:custom-agent`, `label:mcp-server`, `label:iac`

The seven supporting labels (`request`, `bug`, `skill`, `custom-agent`, `mcp-server`, `iac`, `other`) have already been created in the repo.

## Testing

- Validated all four YAML files parse successfully.
- Issue forms take effect once merged to the default branch.