### PR TITLE
Add SUPPORT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The template supports enabling/disabling policies per skill, optional region res
 
 We welcome contributions of new skills and improvements to existing ones. See [CONTRIBUTING](CONTRIBUTING.md) for guidelines.
 
+## Support
+
+Need help, found a bug, or want to suggest a new tool? See [SUPPORT](SUPPORT.md) for how to get support and where to file issues.
+
 ## References
 
 ### AWS Documentation

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,29 @@
+# Support
+
+Thank you for using the AWS DevOps Agent Tools. Here's how to get help.
+
+## Documentation
+
+Visit the [DevOps Agent Tools home page](https://aws.github.io/tools-for-devops-agent/), where you can [learn how to get started with the tools](https://aws.github.io/tools-for-devops-agent/getting-started/), and browse the tools catalogs, including [skills](https://aws.github.io/tools-for-devops-agent/skills/), [custom agents](https://aws.github.io/tools-for-devops-agent/custom-agents/), and [MCP servers](https://aws.github.io/tools-for-devops-agent/mcp-servers/).  
+To learn more about DevOps Agent, check the [DevOps Agent user guide](https://docs.aws.amazon.com/devopsagent/latest/userguide/about-aws-devops-agent.html).
+
+## Bug reports
+
+Found a problem with an existing tool? Please open a [bug report](https://github.com/aws/tools-for-devops-agent/issues/new?template=bug-report.yml) on GitHub. Include the affected tool, what you observed, the expected behaviour, steps to reproduce, and any relevant environment details.
+
+## New tool requests
+
+Want to suggest a new tool? Please open a [tool request](https://github.com/aws/tools-for-devops-agent/issues/new?template=community-request.yml) on GitHub with a clear description of the tool and the operational problem it solves.
+
+If you'd like to build and contribute the tool yourself, see [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
+
+## Security vulnerabilities
+
+Do **not** open a public GitHub issue for security concerns. Report vulnerabilities through the [AWS vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/) or email aws-security@amazon.com.
+
+## AWS support
+
+For issues with AWS services themselves (as opposed to these tools), use your existing AWS support channels:
+
+- [AWS Support Center](https://console.aws.amazon.com/support/home) if you have an AWS Support plan.
+- [AWS re:Post](https://repost.aws/) for community-driven Q&A.


### PR DESCRIPTION
## Description

Adds a `SUPPORT.md` to the repo root describing how users get help, and links it from the README.

Structure adapted from the [agent-toolkit-for-aws SUPPORT.md](https://github.com/aws/agent-toolkit-for-aws/blob/main/SUPPORT.md), tailored to this repo:

- **Documentation** — points to this repo's docs site (home, Getting Started, and the Skills / Custom Agents / MCP Servers catalogs) plus the DevOps Agent User Guide.
- **Bug reports** — links to the `bug-report.yml` issue template.
- **New tool requests** — links to the `community-request.yml` issue template, and cross-links CONTRIBUTING.md for self-contributors.
- **Security vulnerabilities** — directs to the AWS vulnerability reporting page (no local SECURITY.md exists in this repo).
- **AWS support** — Support Center and re:Post for AWS service issues.

Also adds a **Support** section to the README linking to SUPPORT.md.

## Testing

- Verified the docs catalog links resolve to real pages (Skills, Custom Agents, MCP Servers all exist in the mkdocs nav).
- Confirmed the issue-template `?template=` filenames match the templates in `.github/ISSUE_TEMPLATE/`.