### PR TITLE
docs(eks-mcp): Fix corrupted README title and sample alignment

### DIFF
--- a/mcp/aws-eks-node-diagnostics-mcp/README.md
+++ b/mcp/aws-eks-node-diagnostics-mcp/README.md
@@ -1,4 +1,4 @@
-lets have two gates, # EKS Node Diagnostics MCP
+# EKS Node Diagnostics MCP
 
 > **⚠️ Proof of Concept (POC):** This project is a proof of concept and should be tested in non-production environments first. Validate thoroughly in a staging or development account before using with production workloads.
 
@@ -107,10 +107,10 @@ Select [1/2/3] (default: 1):
 ```
 Found 4 EKS cluster(s):
 
-  1) prod-cluster    (us-east-1)
-  2) dev-cluster     (us-east-1)
-  3) analytics        (us-west-2)
-  4) eu-cluster       (eu-west-1)
+  1) prod-cluster  (us-east-1)
+  2) dev-cluster  (us-east-1)
+  3) analytics  (us-west-2)
+  4) eu-cluster  (eu-west-1)
 
   a) All clusters
 


### PR DESCRIPTION
## Description

Fixes two unrelated defects in `mcp/aws-eks-node-diagnostics-mcp/README.md`, both currently live on `main`.

**1. Corrupted H1 title.** The heading read `lets have two gates, # EKS Node Diagnostics MCP`. Because the `#` was no longer at the start of the line, it stopped rendering as a heading and the title displayed as body text. The stray prose was an editing slip introduced in c5aa812 (merged via #41); `git blame` confirms every prior commit had a clean `# EKS Node Diagnostics MCP`, so this restores the original rather than inventing a new title.

**2. Misaligned Step 2 sample output.** The four cluster rows were hand-padded inconsistently, so the `(region)` column landed at two different offsets:

```
  1) prod-cluster    (us-east-1)     <- paren at col 21
  2) dev-cluster     (us-east-1)     <- col 21
  3) analytics        (us-west-2)    <- col 22
  4) eu-cluster       (eu-west-1)    <- col 22
```

The padding should not have been there at all. `deploy.sh` prints:

```bash
echo "  ${IDX}) ${C_NAME}  (${C_REGION})"
```

Two literal spaces, no column padding, so the aligned-looking sample never matched real output. The block now reproduces actual script output exactly.

The Step 3 node-role sample is intentionally left alone: its parens sit at columns 26/27/28, which looks ragged but is correct, since `ROLE_SOURCES` is built as `"${ROLE_NAME}  (${C_NAME} / ${C_REGION})"` using the same two-space convention.

Documentation only. No code, config, or behavior changes.

## Type of change

- [ ] New skill
- [ ] New custom agent
- [ ] Update to an existing skill or agent
- [x] Documentation or infrastructure change

## Testing

- Reproduced the Step 2 block by running `deploy.sh`s own emit loop over the same sample data and `diff`ing against the README; the committed block is byte-identical to real output.
- Verified the restored title against `git blame` / `git show` across the preceding 10 commits that touched the file.
- Checked the rest of the README for the same class of problem and found none: all 9 markdown tables have consistent column counts and valid separator rows, and no other fenced block has a ragged column.
- Cross-checked the counts the README claims while in there, all accurate: 19 tools match the routing table in `ssm-automation-enhanced.py`, the 17 read-only / 2 mutating split is right, and there are exactly 41 files in `sops/runbooks/` spread across categories A-K plus Z as the table states.

## License confirmation

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache License 2.0.